### PR TITLE
feat: render today marker line in the timeline

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -36,6 +36,9 @@
   /* 액센트 */
   --accent: #3b82f6;
 
+  /* 오늘 마커 */
+  --today-marker: #f43f5e;
+
   /* 트랜지션 */
   --transition-fast: 150ms ease;
   --transition-normal: 200ms ease;
@@ -61,6 +64,8 @@
   --bar-shadow-drag: 0 8px 24px rgba(0, 0, 0, 0.4);
 
   --arrow: #71717a;
+
+  --today-marker: #fb7185;
 }
 
 /* ===== BASE LAYOUT ===== */
@@ -263,6 +268,19 @@
   align-items: center;
   border-bottom: 1px solid var(--border-subtle);
   pointer-events: none;
+}
+
+/* ===== TODAY MARKER ===== */
+.gantt-today-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: var(--today-marker);
+  opacity: 0.7;
+  pointer-events: none;
+  z-index: 2;
 }
 
 /* ===== DEPENDENCY ARROWS ===== */

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -2,13 +2,14 @@ import GanttBar from "components/GanttBar";
 import GanttChartHeader from "components/GanttChartHeader";
 import GanttDependencyArrows from "components/GanttDependencyArrows";
 import ScaleSelector from "components/ScaleSelector";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useGanttSelectors } from "hooks/useGanttSelectors";
 import { useGanttVirtualization } from "hooks/useGanttVirtualization";
 import { useResolvedTheme } from "hooks/useResolvedTheme";
 import { GanttScaleKey, GanttTheme } from "types/gantt";
 import { Task } from "types/task";
-import { computeTimelineData } from "utils/timeline";
+import dayjs from "utils/dayjs";
+import { calculateDateOffsetPx, computeTimelineData } from "utils/timeline";
 
 /** Gantt 컴포넌트 기본값 */
 const DEFAULT_HEIGHT = 600;
@@ -107,6 +108,12 @@ function Gantt({
     setSelectedScale(scale);
   };
 
+  // 오늘 마커 오프셋 (타임라인 범위 밖이면 null)
+  const todayOffsetPx = useMemo(
+    () => calculateDateOffsetPx(dayjs(), bottomRowCells, selectedScale),
+    [bottomRowCells, selectedScale]
+  );
+
   // 전체 너비 계산
   const totalWidth = getTotalWidth();
 
@@ -167,6 +174,15 @@ function Gantt({
                 );
               })}
             </div>
+
+            {/* 오늘 마커 */}
+            {todayOffsetPx !== null && (
+              <div
+                className="gantt-today-marker"
+                style={{ left: `${todayOffsetPx}px` }}
+                aria-hidden="true"
+              />
+            )}
 
             {/* 의존성 화살표 */}
             <GanttDependencyArrows transformedTasks={transformedTasks} />

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -78,6 +78,36 @@ export function calculateDateOffsets(
   };
 }
 
+/**
+ * 특정 날짜의 타임라인 px 오프셋 계산
+ * 타임라인 범위 밖이면 null 반환
+ */
+export function calculateDateOffsetPx(
+  date: Dayjs,
+  timelineTicks: GanttBottomRowCell[],
+  scaleKey: GanttScaleKey
+): number | null {
+  if (!timelineTicks.length) return null;
+
+  const { tickUnit, unitPerTick } = GANTT_SCALE_CONFIG[scaleKey];
+  const time = date.valueOf();
+
+  if (time < timelineTicks[0].startDate.valueOf()) return null;
+
+  let offset = 0;
+  for (const tick of timelineTicks) {
+    const tickStart = tick.startDate.valueOf();
+    const tickEnd = tick.startDate.add(unitPerTick, tickUnit).valueOf();
+
+    if (time < tickEnd) {
+      return offset + ((time - tickStart) / (tickEnd - tickStart)) * tick.widthPx;
+    }
+    offset += tick.widthPx;
+  }
+
+  return null;
+}
+
 function findDateRangeFromTasks(
   tasks: Task[]
 ): { minDate: Dayjs; maxDate: Dayjs } {

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -3,7 +3,12 @@ import dayjs from 'utils/dayjs';
 import type { Task } from 'types/task';
 import { getSmartGanttPath } from './arrowPath';
 import { processHeaderGroups } from './headerUtils';
-import { calculateDateOffsets, computeTimelineData, createTopHeaderGroups } from './timeline';
+import {
+  calculateDateOffsetPx,
+  calculateDateOffsets,
+  computeTimelineData,
+  createTopHeaderGroups,
+} from './timeline';
 import { transformTasks } from './transformData';
 
 // month scale: tickUnit day, unitPerTick 1, basePxPerDragStep 32 -> every tick is exactly 32px.
@@ -61,6 +66,22 @@ describe('calculateDateOffsets', () => {
       barMarginLeftAmount: 0,
       barWidthSize: 0,
     });
+  });
+});
+
+describe('calculateDateOffsetPx', () => {
+  const t = ticks('2025-01-01', '2025-01-02', '2025-01-03');
+
+  it('offsets whole and partial ticks', () => {
+    expect(calculateDateOffsetPx(dayjs('2025-01-01'), t, 'month')).toBe(0);
+    expect(calculateDateOffsetPx(dayjs('2025-01-02'), t, 'month')).toBe(32);
+    expect(calculateDateOffsetPx(dayjs('2025-01-02T12:00'), t, 'month')).toBe(48);
+  });
+
+  it('returns null outside the timeline range and for no ticks', () => {
+    expect(calculateDateOffsetPx(dayjs('2024-12-31'), t, 'month')).toBeNull();
+    expect(calculateDateOffsetPx(dayjs('2025-01-04'), t, 'month')).toBeNull();
+    expect(calculateDateOffsetPx(dayjs(), [], 'month')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #19.

The README advertised a today marker that did not exist. This adds one:

- `calculateDateOffsetPx(date, ticks, scale)` in `src/utils/timeline.ts` — px offset of an arbitrary date on the timeline, `null` outside the rendered range (unit-tested for whole/partial ticks, out-of-range, and empty timelines).
- A `.gantt-today-marker` line rendered in the content area at the current time, hidden when today is outside the timeline, behind bars/arrows (z-index 2).
- New `--today-marker` design token for light (`#f43f5e`) and dark (`#fb7185`) themes.

Verified in the demo app at month/week/year scales and both themes: marker lands exactly on the Sep 1 bottom-tick boundary (x=613 vs tick at 612 + current-time fraction). While verifying I found a pre-existing top-header misalignment, filed separately as #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)