### PR TITLE
feat: weekend and holiday shading (configurable non-working days)

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -36,6 +36,9 @@
   /* 액센트 */
   --accent: #3b82f6;
 
+  /* 비근무일 음영 */
+  --non-working-bg: rgba(0, 0, 0, 0.035);
+
   /* 트랜지션 */
   --transition-fast: 150ms ease;
   --transition-normal: 200ms ease;
@@ -61,6 +64,8 @@
   --bar-shadow-drag: 0 8px 24px rgba(0, 0, 0, 0.4);
 
   --arrow: #71717a;
+
+  --non-working-bg: rgba(255, 255, 255, 0.03);
 }
 
 /* ===== BASE LAYOUT ===== */
@@ -241,6 +246,24 @@
 .gantt-content {
   position: relative;
   background: var(--background);
+}
+
+/* ===== NON-WORKING DAY SHADING ===== */
+.gantt-non-working-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.gantt-non-working-range {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: var(--non-working-bg);
 }
 
 /* ===== TASK ROWS (배경 전용) ===== */

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -2,13 +2,14 @@ import GanttBar from "components/GanttBar";
 import GanttChartHeader from "components/GanttChartHeader";
 import GanttDependencyArrows from "components/GanttDependencyArrows";
 import ScaleSelector from "components/ScaleSelector";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { Dayjs } from "dayjs";
 import { useGanttSelectors } from "hooks/useGanttSelectors";
 import { useGanttVirtualization } from "hooks/useGanttVirtualization";
 import { useResolvedTheme } from "hooks/useResolvedTheme";
 import { GanttScaleKey, GanttTheme } from "types/gantt";
 import { Task } from "types/task";
-import { computeTimelineData } from "utils/timeline";
+import { computeNonWorkingRanges, computeTimelineData } from "utils/timeline";
 
 /** Gantt 컴포넌트 기본값 */
 const DEFAULT_HEIGHT = 600;
@@ -30,6 +31,12 @@ export interface GanttProps {
   defaultScale?: GanttScaleKey;
   /** 추가 CSS 클래스명 */
   className?: string;
+  /** 주말/휴일 음영 표시 여부 (기본 true) */
+  showNonWorkingDays?: boolean;
+  /** 휴일 목록 (ISO 날짜 문자열, 예: '2026-01-01') */
+  holidays?: string[];
+  /** 비근무일 판별 커스텀 함수 - 지정 시 기본 주말/휴일 판별을 대체 */
+  isNonWorkingDay?: (date: Dayjs) => boolean;
 }
 
 /**
@@ -44,6 +51,9 @@ function Gantt({
   theme,
   defaultScale = DEFAULT_SCALE,
   className,
+  showNonWorkingDays = true,
+  holidays,
+  isNonWorkingDay,
 }: GanttProps) {
   // 스토어 상태 및 액션
   const {
@@ -107,6 +117,31 @@ function Gantt({
     setSelectedScale(scale);
   };
 
+  // 비근무일 음영 범위 계산
+  const nonWorkingRanges = useMemo(() => {
+    if (!showNonWorkingDays) return [];
+
+    const holidaySet = new Set(holidays);
+    const isOffDay =
+      isNonWorkingDay ??
+      ((date: Dayjs) => {
+        const dayOfWeek = date.day();
+        return (
+          dayOfWeek === 0 ||
+          dayOfWeek === 6 ||
+          holidaySet.has(date.format("YYYY-MM-DD"))
+        );
+      });
+
+    return computeNonWorkingRanges(bottomRowCells, selectedScale, isOffDay);
+  }, [
+    showNonWorkingDays,
+    holidays,
+    isNonWorkingDay,
+    bottomRowCells,
+    selectedScale,
+  ]);
+
   // 전체 너비 계산
   const totalWidth = getTotalWidth();
 
@@ -151,6 +186,22 @@ function Gantt({
               width: `${totalWidth}px`,
             }}
           >
+            {/* 비근무일 음영 */}
+            {nonWorkingRanges.length > 0 && (
+              <div className="gantt-non-working-layer" aria-hidden="true">
+                {nonWorkingRanges.map((range) => (
+                  <div
+                    key={range.left}
+                    className="gantt-non-working-range"
+                    style={{
+                      left: `${range.left}px`,
+                      width: `${range.width}px`,
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+
             {/* 태스크 행 (배경) */}
             <div className="gantt-rows">
               {rowVirtualizer.getVirtualItems().map((virtualRow) => {

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -14,6 +14,43 @@ export interface TimelineData {
   transformedTasks: TaskTransformed[];
 }
 
+export interface NonWorkingRange {
+  left: number;
+  width: number;
+}
+
+/**
+ * 비근무일(주말/휴일) 셀을 px 범위로 병합해 반환
+ * 틱 단위가 하루 이하인 스케일에서만 적용
+ */
+export function computeNonWorkingRanges(
+  timelineTicks: GanttBottomRowCell[],
+  scaleKey: GanttScaleKey,
+  isNonWorkingDay: (date: Dayjs) => boolean
+): NonWorkingRange[] {
+  const { tickUnit } = GANTT_SCALE_CONFIG[scaleKey];
+  if (tickUnit !== "day" && tickUnit !== "hour") return [];
+
+  const ranges: NonWorkingRange[] = [];
+  let offset = 0;
+  let prevNonWorking = false;
+
+  for (const tick of timelineTicks) {
+    const nonWorking = isNonWorkingDay(tick.startDate);
+    if (nonWorking) {
+      if (prevNonWorking) {
+        ranges[ranges.length - 1].width += tick.widthPx;
+      } else {
+        ranges.push({ left: offset, width: tick.widthPx });
+      }
+    }
+    prevNonWorking = nonWorking;
+    offset += tick.widthPx;
+  }
+
+  return ranges;
+}
+
 export function calculateDateOffsets(
   startDate: Dayjs,
   endDate: Dayjs,

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -3,7 +3,12 @@ import dayjs from 'utils/dayjs';
 import type { Task } from 'types/task';
 import { getSmartGanttPath } from './arrowPath';
 import { processHeaderGroups } from './headerUtils';
-import { calculateDateOffsets, computeTimelineData, createTopHeaderGroups } from './timeline';
+import {
+  calculateDateOffsets,
+  computeNonWorkingRanges,
+  computeTimelineData,
+  createTopHeaderGroups,
+} from './timeline';
 import { transformTasks } from './transformData';
 
 // month scale: tickUnit day, unitPerTick 1, basePxPerDragStep 32 -> every tick is exactly 32px.
@@ -61,6 +66,40 @@ describe('calculateDateOffsets', () => {
       barMarginLeftAmount: 0,
       barWidthSize: 0,
     });
+  });
+});
+
+describe('computeNonWorkingRanges', () => {
+  // 2025-01-01 is a Wednesday; Jan 4 (Sat) and Jan 5 (Sun) are the weekend.
+  const week = ticks(
+    '2025-01-01',
+    '2025-01-02',
+    '2025-01-03',
+    '2025-01-04',
+    '2025-01-05',
+    '2025-01-06',
+    '2025-01-07',
+  );
+  const isWeekend = (d: ReturnType<typeof dayjs>) => d.day() === 0 || d.day() === 6;
+
+  it('merges adjacent weekend ticks into one range', () => {
+    expect(computeNonWorkingRanges(week, 'month', isWeekend)).toEqual([
+      { left: 96, width: 64 },
+    ]);
+  });
+
+  it('keeps non-adjacent ranges separate', () => {
+    const withHoliday = (d: ReturnType<typeof dayjs>) =>
+      isWeekend(d) || d.format('YYYY-MM-DD') === '2025-01-07';
+    expect(computeNonWorkingRanges(week, 'month', withHoliday)).toEqual([
+      { left: 96, width: 64 },
+      { left: 192, width: 32 },
+    ]);
+  });
+
+  it('returns nothing for scales coarser than a day', () => {
+    expect(computeNonWorkingRanges(week, 'year', isWeekend)).toEqual([]);
+    expect(computeNonWorkingRanges([], 'month', isWeekend)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #20.

- `computeNonWorkingRanges(ticks, scale, isNonWorkingDay)` in `src/utils/timeline.ts` merges adjacent non-working ticks into px ranges; returns nothing for scales coarser than a day (year). Unit-tested (merge, non-adjacent holiday, coarse scale, empty).
- New props on `GanttProps`: `showNonWorkingDays` (default `true`), `holidays?: string[]` (ISO dates), `isNonWorkingDay?: (date: Dayjs) => boolean` which fully replaces the default Sat/Sun + holidays check.
- Shading renders as a background layer (z-index 0, pointer-events none) behind rows/bars, themed via a new `--non-working-bg` token for light and dark.

Verified in the demo app: month scale stripes land on actual Sat/Sun pairs (Sep 5-6, 12-13, 19-20, 26-27 2026), week scale merges the weekend into one block, day scale produces 48-hour-tick blocks on a 7-day period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)