### PR TITLE
feat: milestone task type (diamond marker)

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -57,6 +57,16 @@ export const sourceTasks: Task[] = [
     dependencies: [{ targetId: '3', type: 'FS' }],
   },
   {
+    id: '51',
+    name: 'Design Sign-off',
+    startDate: formatISO(setTime(addDays(baseDate, 8), 9)),
+    endDate: formatISO(setTime(addDays(baseDate, 8), 9)),
+    parentId: null,
+    sequence: '3.5',
+    type: 'milestone',
+    dependencies: [{ targetId: '4', type: 'FS' }],
+  },
+  {
     id: '5',
     name: 'Frontend Architecture Planning',
     startDate: formatISO(setTime(addDays(baseDate, 8), 9)),

--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -39,6 +39,10 @@
   /* 오늘 마커 */
   --today-marker: #f43f5e;
 
+  /* 마일스톤 */
+  --milestone-bg: #52525b;
+  --milestone-bg-hover: #3f3f46;
+
   /* 트랜지션 */
   --transition-fast: 150ms ease;
   --transition-normal: 200ms ease;
@@ -66,6 +70,9 @@
   --arrow: #71717a;
 
   --today-marker: #fb7185;
+
+  --milestone-bg: #d4d4d8;
+  --milestone-bg-hover: #e4e4e7;
 }
 
 /* ===== BASE LAYOUT ===== */
@@ -375,6 +382,53 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  pointer-events: none;
+}
+
+/* ===== MILESTONE ===== */
+.gantt-milestone {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  user-select: none;
+  cursor: grab;
+}
+
+.gantt-milestone-diamond {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  background: var(--milestone-bg);
+  border-radius: 3px;
+  transform: rotate(45deg);
+  box-shadow: var(--bar-shadow);
+  transition: background var(--transition-fast),
+    box-shadow var(--transition-normal);
+}
+
+.gantt-milestone:hover .gantt-milestone-diamond {
+  background: var(--milestone-bg-hover);
+  box-shadow: var(--bar-shadow-hover);
+}
+
+.gantt-milestone:active,
+.gantt-milestone.dragging {
+  cursor: grabbing;
+  z-index: 100;
+}
+
+.gantt-milestone.dragging .gantt-milestone-diamond {
+  box-shadow: var(--bar-shadow-drag);
+}
+
+.gantt-milestone-name {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--foreground);
+  white-space: nowrap;
   pointer-events: none;
 }
 

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -1,9 +1,9 @@
-import { NODE_HEIGHT } from "constants/gantt";
+import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from "constants/gantt";
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
 import { useRef, useState, useCallback } from "react";
 import { useGanttStore } from "stores/store";
 import { GanttScaleKey } from "types/gantt";
-import { Task, TaskTransformed } from "types/task";
+import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 
 // 엣지 감지 영역 (px)
 const EDGE_THRESHOLD = 8;
@@ -41,29 +41,41 @@ export default function GanttBar({
   const finalLeft = currentTask.barLeft + offsetX;
   const finalWidth = currentTask.barWidth + offsetWidth;
 
-  // 마우스 위치에 따른 커서 변경
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const bar = barRef.current;
-    if (!bar) return;
+  const isMilestone = isMilestoneTask(currentTask);
 
-    const rect = bar.getBoundingClientRect();
-    const relativeX = e.clientX - rect.left;
+  // 마우스 위치에 따른 커서 변경 (마일스톤은 리사이즈 없음)
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isMilestone) return;
 
-    if (relativeX <= EDGE_THRESHOLD || relativeX >= rect.width - EDGE_THRESHOLD) {
-      setCursor("ew-resize");
-    } else {
-      setCursor("grab");
-    }
-  }, []);
+      const bar = barRef.current;
+      if (!bar) return;
+
+      const rect = bar.getBoundingClientRect();
+      const relativeX = e.clientX - rect.left;
+
+      if (
+        relativeX <= EDGE_THRESHOLD ||
+        relativeX >= rect.width - EDGE_THRESHOLD
+      ) {
+        setCursor("ew-resize");
+      } else {
+        setCursor("grab");
+      }
+    },
+    [isMilestone]
+  );
 
   // 툴팁 텍스트 생성 (모드에 따라 다르게 표시)
   const format = DATE_FORMATS[selectedScale];
   const getTooltipText = (mode: DragMode | null) => {
     if (!liveOffset) return "";
-    
+
     const startText = liveOffset.offsetStartDate.format(format);
     const endText = liveOffset.offsetEndDate.format(format);
-    
+
+    if (isMilestone) return startText;
+
     switch (mode) {
       case "left":
         return `Start: ${startText}`;
@@ -74,6 +86,36 @@ export default function GanttBar({
         return `${startText} → ${endText}`;
     }
   };
+
+  // 마일스톤: startDate 한 점에 다이아몬드 + 우측 라벨
+  if (isMilestone) {
+    return (
+      <div
+        ref={barRef}
+        id={`task-${currentTask.id}`}
+        className={`gantt-milestone${isDragging ? " dragging" : ""}`}
+        onPointerDown={onPointerDown}
+        style={{
+          transform: `translateX(${finalLeft - MILESTONE_HALF_DIAGONAL}px)`,
+          height: NODE_HEIGHT / 2,
+          cursor: isDragging ? "grabbing" : "grab",
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={`마일스톤: ${currentTask.name}`}
+      >
+        <div className="gantt-milestone-diamond" />
+        <span className="gantt-milestone-name">{currentTask.name}</span>
+
+        {/* 드래그 중 툴팁 */}
+        {isDragging && liveOffset && (
+          <div className="gantt-bar-tooltip" role="status" aria-live="polite">
+            {getTooltipText(dragMode)}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -1,6 +1,6 @@
-import { NODE_HEIGHT } from "constants/gantt";
+import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from "constants/gantt";
 import { useGanttStore } from "stores/store";
-import { RenderedDependency, TaskTransformed } from "types/task";
+import { isMilestoneTask, RenderedDependency, TaskTransformed } from "types/task";
 import { getSmartGanttPath } from "utils/arrowPath";
 
 interface Props {
@@ -23,11 +23,20 @@ function calculateArrowCoords(
   const fromY = targetIndex * rowHeight + barCenterY;
   const toY = sourceIndex * rowHeight + barCenterY;
 
-  const leftX = targetTask.barLeft;
-  const rightX = targetTask.barLeft + targetTask.barWidth;
+  // 마일스톤은 다이아몬드 꼭짓점에 화살표 연결
+  const targetHalf = isMilestoneTask(targetTask) ? MILESTONE_HALF_DIAGONAL : 0;
+  const sourceHalf = isMilestoneTask(sourceTask) ? MILESTONE_HALF_DIAGONAL : 0;
 
-  const currentLeftX = sourceTask.barLeft + sourceOffset.offsetX;
-  const currentRightX = currentLeftX + sourceTask.barWidth + sourceOffset.offsetWidth;
+  const leftX = targetTask.barLeft - targetHalf;
+  const rightX = targetTask.barLeft + (targetHalf || targetTask.barWidth);
+
+  const currentLeftX = sourceTask.barLeft + sourceOffset.offsetX - sourceHalf;
+  const currentRightX = sourceHalf
+    ? sourceTask.barLeft + sourceOffset.offsetX + sourceHalf
+    : sourceTask.barLeft +
+      sourceOffset.offsetX +
+      sourceTask.barWidth +
+      sourceOffset.offsetWidth;
 
   // 의존성 타입에 따른 X 좌표 설정
   // FS: 선행 태스크 우측 → 후행 태스크 좌측

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -2,6 +2,10 @@ import { GanttScaleConfig, GanttScaleKey } from 'types/gantt';
 
 export const NODE_HEIGHT = 38;
 export const TIMELINE_SHIFT_BUFFER = 5;
+/** 마일스톤 다이아몬드 한 변 길이 (px, 45도 회전 전) */
+export const MILESTONE_SIZE = 16;
+/** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
+export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
 export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
   day: {

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -2,7 +2,7 @@ import { GANTT_SCALE_CONFIG } from "constants/gantt";
 import { useRef } from "react";
 import { useGanttStore } from "stores/store";
 import { GanttDragOffset } from "types/gantt";
-import { Task, TaskTransformed } from "types/task";
+import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
 
 export type DragMode = "bar" | "left" | "right";
@@ -48,8 +48,10 @@ export function useGanttBarDrag(
   const scaleConfig = GANTT_SCALE_CONFIG[selectedScale];
   const { basePxPerDragStep, dragStepAmount, dragStepUnit } = scaleConfig;
 
-  // 드래그 모드 감지
+  // 드래그 모드 감지 (마일스톤은 리사이즈 불가 - 항상 이동)
   const detectDragMode = (e: React.PointerEvent<HTMLDivElement>): DragMode => {
+    if (isMilestoneTask(task)) return "bar";
+
     const rect = e.currentTarget.getBoundingClientRect();
     const relativeX = e.clientX - rect.left;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,5 +6,5 @@ export { default as ReactGanttChart } from './pages/Gantt';
 
 // 타입 내보내기
 export type { GanttProps } from './pages/Gantt';
-export type { Task, TaskDependency, DependencyType } from './types/task';
+export type { Task, TaskDependency, DependencyType, TaskType } from './types/task';
 export type { GanttScaleKey, GanttTheme } from './types/gantt';

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,3 +1,5 @@
+export type TaskType = 'task' | 'milestone';
+
 export interface Task {
   id: string;
   name: string;
@@ -5,7 +7,13 @@ export interface Task {
   endDate: string;
   parentId: string | null;
   sequence: string;
+  /** 태스크 종류 - 'milestone'은 startDate 기준 다이아몬드로 렌더링 (기본 'task') */
+  type?: TaskType;
   dependencies?: TaskDependency[];
+}
+
+export function isMilestoneTask(task: Pick<Task, 'type'>): boolean {
+  return task.type === 'milestone';
 }
 
 export interface TaskDependency {

--- a/src/utils/transformData.ts
+++ b/src/utils/transformData.ts
@@ -1,5 +1,5 @@
 import { GanttBottomRowCell, GanttScaleKey } from "types/gantt";
-import { Task, TaskTransformed } from "types/task";
+import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
 import { calculateDateOffsets } from "./timeline";
 
@@ -41,9 +41,10 @@ export function transformTasks(
     const order = index + 1;
 
     // Calculate bar position and width
+    // 마일스톤은 startDate 한 점 기준 (endDate 무시)
     const { barMarginLeftAmount, barWidthSize } = calculateDateOffsets(
       dayjs(task.startDate),
-      dayjs(task.endDate),
+      isMilestoneTask(task) ? dayjs(task.startDate) : dayjs(task.endDate),
       timelineTicks,
       selectedScale
     );

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -39,6 +39,16 @@ describe('transformTasks', () => {
     expect(out.map((t) => t.depth)).toEqual([1, 1, 0]);
     expect(out.map((t) => t.order)).toEqual([1, 2, 3]);
   });
+
+  it('positions milestones at startDate as a point, ignoring endDate', () => {
+    const [m] = transformTasks(
+      [{ ...task('m', '1', '2025-01-02', '2025-01-03'), type: 'milestone' as const }],
+      ticks('2025-01-01', '2025-01-02', '2025-01-03'),
+      'month',
+    );
+    expect(m.barLeft).toBe(32);
+    expect(m.barWidth).toBe(1);
+  });
 });
 
 describe('calculateDateOffsets', () => {


### PR DESCRIPTION
Closes #21.

- `Task.type?: 'task' | 'milestone'` plus an `isMilestoneTask()` helper; `TaskType` exported from the package entry.
- `transformTasks` positions a milestone at `startDate` as a point (endDate ignored), so bad or absent end dates cannot stretch it.
- `GanttBar` renders a rotated-square diamond with the name beside it (a diamond has no room for an inside label), centered on the date via a new `MILESTONE_HALF_DIAGONAL` constant.
- Milestones are draggable but never resizable: `detectDragMode` short-circuits to `"bar"`, and the hover cursor never becomes `ew-resize`. The drag tooltip shows a single date instead of a range.
- Dependency arrows anchor to the diamond's left/right vertices for both source and target, so FS/SS/FF/SF connect correctly whether the milestone is predecessor or successor.
- New `--milestone-bg` / `--milestone-bg-hover` tokens for light and dark; demo data gained a "Design Sign-off" milestone.

Verified in the demo app: diamond centered on its date with the FS arrow landing on the left vertex, drag moves it with no resize handles, unit test asserts point positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)