### PR TITLE
feat: narrow bars stay readable and grabbable

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -371,6 +371,16 @@
   opacity: 0.7;
 }
 
+/* 좁은 바: 리사이즈 핸들 숨김 (전체가 이동 핸들) */
+.gantt-task-bar.compact::before,
+.gantt-task-bar.compact::after,
+.gantt-task-bar.compact:hover::before,
+.gantt-task-bar.compact:hover::after,
+.gantt-task-bar.compact.dragging::before,
+.gantt-task-bar.compact.dragging::after {
+  opacity: 0;
+}
+
 /* Task Name */
 .gantt-task-name {
   flex: 1;
@@ -383,6 +393,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
   pointer-events: none;
+}
+
+/* 바가 좁을 때 라벨을 바 오른쪽 바깥에 표시 */
+.gantt-task-name.outside {
+  position: absolute;
+  left: 100%;
+  flex: none;
+  padding: 0 0 0 8px;
+  color: var(--foreground);
+  overflow: visible;
 }
 
 /* ===== MILESTONE ===== */

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -1,12 +1,16 @@
-import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from "constants/gantt";
+import {
+  EDGE_THRESHOLD,
+  MILESTONE_HALF_DIAGONAL,
+  MIN_BAR_WIDTH,
+  MIN_LABEL_INSIDE_WIDTH,
+  MIN_RESIZABLE_WIDTH,
+  NODE_HEIGHT,
+} from "constants/gantt";
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
 import { useRef, useState, useCallback } from "react";
 import { useGanttStore } from "stores/store";
 import { GanttScaleKey } from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
-
-// 엣지 감지 영역 (px)
-const EDGE_THRESHOLD = 8;
 
 // 스케일별 날짜 포맷
 const DATE_FORMATS: Record<GanttScaleKey, string> = {
@@ -38,8 +42,13 @@ export default function GanttBar({
   const offsetWidth = liveOffset?.offsetWidth ?? 0;
 
   // 최종 위치 및 크기 계산
+  // 짧은 태스크도 잡을 수 있도록 최소 너비 보장, 좁으면 라벨을 바 밖으로
   const finalLeft = currentTask.barLeft + offsetX;
-  const finalWidth = currentTask.barWidth + offsetWidth;
+  const finalWidth = Math.max(
+    currentTask.barWidth + offsetWidth,
+    MIN_BAR_WIDTH
+  );
+  const labelOutside = finalWidth < MIN_LABEL_INSIDE_WIDTH;
 
   const isMilestone = isMilestoneTask(currentTask);
 
@@ -52,6 +61,11 @@ export default function GanttBar({
       if (!bar) return;
 
       const rect = bar.getBoundingClientRect();
+      if (rect.width < MIN_RESIZABLE_WIDTH) {
+        setCursor("grab");
+        return;
+      }
+
       const relativeX = e.clientX - rect.left;
 
       if (
@@ -121,7 +135,9 @@ export default function GanttBar({
     <div
       ref={barRef}
       id={`task-${currentTask.id}`}
-      className={`gantt-task-bar${isDragging ? " dragging" : ""}`}
+      className={`gantt-task-bar${isDragging ? " dragging" : ""}${
+        labelOutside ? " compact" : ""
+      }`}
       onPointerDown={onPointerDown}
       onMouseMove={handleMouseMove}
       onMouseLeave={() => setCursor("grab")}
@@ -135,8 +151,12 @@ export default function GanttBar({
       tabIndex={0}
       aria-label={`태스크: ${currentTask.name}`}
     >
-      <span className="gantt-task-name">{currentTask.name}</span>
-      
+      <span
+        className={`gantt-task-name${labelOutside ? " outside" : ""}`}
+      >
+        {currentTask.name}
+      </span>
+
       {/* 드래그 중 툴팁 */}
       {isDragging && liveOffset && (
         <div className="gantt-bar-tooltip" role="status" aria-live="polite">

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -2,6 +2,14 @@ import { GanttScaleConfig, GanttScaleKey } from 'types/gantt';
 
 export const NODE_HEIGHT = 38;
 export const TIMELINE_SHIFT_BUFFER = 5;
+/** 바가 좁아도 최소한 이 너비로 렌더링 (px) - 짧은 태스크도 잡을 수 있게 */
+export const MIN_BAR_WIDTH = 14;
+/** 이 너비 미만이면 태스크명을 바 바깥에 표시 (px) */
+export const MIN_LABEL_INSIDE_WIDTH = 56;
+/** 리사이즈 엣지 감지 영역 (px) */
+export const EDGE_THRESHOLD = 8;
+/** 바 너비가 이 값 미만이면 엣지 리사이즈 없이 전체를 이동 핸들로 사용 (px) */
+export const MIN_RESIZABLE_WIDTH = EDGE_THRESHOLD * 3;
 /** 마일스톤 다이아몬드 한 변 길이 (px, 45도 회전 전) */
 export const MILESTONE_SIZE = 16;
 /** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -1,4 +1,8 @@
-import { GANTT_SCALE_CONFIG } from "constants/gantt";
+import {
+  EDGE_THRESHOLD,
+  GANTT_SCALE_CONFIG,
+  MIN_RESIZABLE_WIDTH,
+} from "constants/gantt";
 import { useRef } from "react";
 import { useGanttStore } from "stores/store";
 import { GanttDragOffset } from "types/gantt";
@@ -29,9 +33,6 @@ const TIME_UNIT_MULTIPLIERS = {
   month: 60 * 24 * 30,
 } as const;
 
-// 엣지 감지 영역 (px)
-const EDGE_THRESHOLD = 10;
-
 /**
  * Gantt 바 드래그 기능을 제공하는 훅
  */
@@ -48,11 +49,14 @@ export function useGanttBarDrag(
   const scaleConfig = GANTT_SCALE_CONFIG[selectedScale];
   const { basePxPerDragStep, dragStepAmount, dragStepUnit } = scaleConfig;
 
-  // 드래그 모드 감지 (마일스톤은 리사이즈 불가 - 항상 이동)
+  // 드래그 모드 감지
+  // 마일스톤과 좁은 바는 리사이즈 불가 - 엣지 영역이 바 전체를 덮어 이동이 막히는 것을 방지
   const detectDragMode = (e: React.PointerEvent<HTMLDivElement>): DragMode => {
     if (isMilestoneTask(task)) return "bar";
 
     const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width < MIN_RESIZABLE_WIDTH) return "bar";
+
     const relativeX = e.clientX - rect.left;
 
     if (relativeX <= EDGE_THRESHOLD) return "left";


### PR DESCRIPTION
Closes #58. Stacked on #60 (milestone diamonds) — base retargets to `main` once that merges.

Short tasks used to render as a few unusable pixels: the label was invisible and the two 8-10px resize edge zones covered the whole bar, so the task could not be moved at all.

- `MIN_BAR_WIDTH` (14px) floors the rendered bar width, so every task is clickable.
- Below `MIN_LABEL_INSIDE_WIDTH` (56px) the task name renders outside the bar, to its right, instead of being clipped to nothing.
- Below `MIN_RESIZABLE_WIDTH` (3x the edge threshold) edge-resize detection is skipped in both the drag hook and the hover-cursor logic, and the grip pseudo-elements are hidden — the entire bar becomes a move handle. Resizing is still available after zooming in.
- The edge threshold moved into `constants/gantt.ts`; it was previously duplicated as 8 in `GanttBar` and 10 in `useGanttBarDrag`, so the cursor and the actual drag mode disagreed in the 8-10px band.

Verified in the demo app at month scale: "Project Kickoff" (2-hour task) and "Design Kickoff Meeting" now show their names beside the bar and drag as a unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)