### PR TITLE
feat: drag guides with live date labels on the header

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -152,9 +152,44 @@
 }
 
 .gantt-scroll-container {
+  position: relative;
   width: 100%;
   height: 100%;
   overflow: auto;
+}
+
+/* ===== DRAG GUIDES ===== */
+.gantt-drag-guides {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 40;
+  pointer-events: none;
+}
+
+.gantt-drag-guide {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--accent);
+  opacity: 0.9;
+}
+
+.gantt-drag-guide-label {
+  position: absolute;
+  top: 6px;
+  left: 0;
+  transform: translateX(-50%);
+  padding: 3px 7px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .gantt-scroll-container::-webkit-scrollbar {

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -1,4 +1,5 @@
 import {
+  DATE_FORMATS,
   EDGE_THRESHOLD,
   MILESTONE_HALF_DIAGONAL,
   MIN_BAR_WIDTH,
@@ -9,16 +10,7 @@ import {
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
 import { useRef, useState, useCallback } from "react";
 import { useGanttStore } from "stores/store";
-import { GanttScaleKey } from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
-
-// 스케일별 날짜 포맷
-const DATE_FORMATS: Record<GanttScaleKey, string> = {
-  day: "MMM D, h A",
-  week: "MMM D",
-  month: "MMM D",
-  year: "MMM YYYY",
-};
 
 interface GanttBarProps {
   currentTask: TaskTransformed;

--- a/src/components/GanttDragGuides.tsx
+++ b/src/components/GanttDragGuides.tsx
@@ -1,0 +1,49 @@
+import { DATE_FORMATS } from "constants/gantt";
+import { useGanttStore } from "stores/store";
+import { isMilestoneTask } from "types/task";
+
+interface GanttDragGuidesProps {
+  width: number;
+}
+
+/**
+ * 드래그 중 시작/종료 지점을 헤더까지 관통하는 세로 가이드로 표시
+ * 각 가이드 상단에 현재 날짜 라벨을 붙여 헤더에서 시점을 바로 읽을 수 있게 한다
+ */
+export default function GanttDragGuides({ width }: GanttDragGuidesProps) {
+  const currentTask = useGanttStore((store) => store.currentTask);
+  const dragOffsets = useGanttStore((store) => store.dragOffsets);
+  const selectedScale = useGanttStore((store) => store.selectedScale);
+
+  const offset = currentTask ? dragOffsets[currentTask.id] : undefined;
+  if (!currentTask || !offset) return null;
+
+  const format = DATE_FORMATS[selectedScale];
+  const startX = currentTask.barLeft + offset.offsetX;
+  const endX = startX + currentTask.barWidth + offset.offsetWidth;
+
+  const guides = isMilestoneTask(currentTask)
+    ? [{ x: startX, label: offset.offsetStartDate.format(format) }]
+    : [
+        { x: startX, label: offset.offsetStartDate.format(format) },
+        { x: endX, label: offset.offsetEndDate.format(format) },
+      ];
+
+  return (
+    <div
+      className="gantt-drag-guides"
+      style={{ width: `${width}px` }}
+      aria-hidden="true"
+    >
+      {guides.map((guide, idx) => (
+        <div
+          key={`guide-${idx}`}
+          className="gantt-drag-guide"
+          style={{ left: `${guide.x}px` }}
+        >
+          <span className="gantt-drag-guide-label">{guide.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -15,6 +15,14 @@ export const MILESTONE_SIZE = 16;
 /** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
 export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
+/** 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) */
+export const DATE_FORMATS: Record<GanttScaleKey, string> = {
+  day: 'MMM D, h A',
+  week: 'MMM D',
+  month: 'MMM D',
+  year: 'MMM YYYY',
+};
+
 export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
   day: {
     labelUnit: 'day',

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -1,6 +1,7 @@
 import GanttBar from "components/GanttBar";
 import GanttChartHeader from "components/GanttChartHeader";
 import GanttDependencyArrows from "components/GanttDependencyArrows";
+import GanttDragGuides from "components/GanttDragGuides";
 import ScaleSelector from "components/ScaleSelector";
 import { useEffect, useMemo, useRef } from "react";
 import { useGanttSelectors } from "hooks/useGanttSelectors";
@@ -140,6 +141,9 @@ function Gantt({
       {/* 메인 차트 영역 */}
       <div className="gantt-main">
         <div ref={scrollRef} className="gantt-scroll-container">
+          {/* 드래그 가이드 (헤더 포함 전체 관통) */}
+          <GanttDragGuides width={totalWidth} />
+
           {/* 헤더 */}
           <div className="gantt-header-wrapper" style={{ width: `${totalWidth}px` }}>
             <GanttChartHeader


### PR DESCRIPTION
Closes #59. Stacked on #61 — base retargets as the stack merges.

While dragging, the only feedback was a tooltip on the bar itself, so placing a bar on a specific date meant counting header columns.

- New `GanttDragGuides` component renders vertical guide lines at the bar's live start and end while a drag is in progress, spanning the header and the full chart body (the guide layer sits inside the scroll container, which is now `position: relative`).
- Each guide carries a date badge pinned at the top, inside the header band — the date is readable where the timeline labels are, not just next to the cursor.
- Milestones get a single guide (they have one date, not a range).
- `DATE_FORMATS` moved from `GanttBar` into `constants/gantt.ts` so the tooltip and the guides format dates identically per scale.

Verified by driving a real pointer drag in the demo app: dragging "Backend Da..." right by 96px shows guides at Sep 18 and Sep 22 with both badges visible in the header, and they disappear on drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)