### PR TITLE
feat: task progress (% complete fill and drag handle)

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -27,6 +27,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 0), 11)),
     parentId: null,
     sequence: '1',
+    progress: 100,
     dependencies: [],
   },
   {
@@ -36,6 +37,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 4), 17)),
     parentId: null,
     sequence: '2',
+    progress: 100,
     dependencies: [{ targetId: '1', type: 'FS' }],
   },
   {
@@ -45,6 +47,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 3), 17)),
     parentId: null,
     sequence: '2.1',
+    progress: 80,
     dependencies: [{ targetId: '2', type: 'SS' }],
   },
   {
@@ -54,6 +57,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 7), 17)),
     parentId: null,
     sequence: '3',
+    progress: 60,
     dependencies: [{ targetId: '3', type: 'FS' }],
   },
   {
@@ -73,6 +77,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 10), 17)),
     parentId: null,
     sequence: '4',
+    progress: 45,
     dependencies: [{ targetId: '4', type: 'FS' }],
   },
   {
@@ -82,6 +87,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 11), 17)),
     parentId: null,
     sequence: '5',
+    progress: 30,
     dependencies: [{ targetId: '4', type: 'FS' }],
   },
   {
@@ -91,6 +97,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 17), 17)),
     parentId: '5',
     sequence: '4.1',
+    progress: 15,
     dependencies: [{ targetId: '5', type: 'FS' }],
   },
   {
@@ -100,6 +107,7 @@ export const sourceTasks: Task[] = [
     endDate: formatISO(setTime(addDays(baseDate, 17), 17)),
     parentId: '6',
     sequence: '5.1',
+    progress: 5,
     dependencies: [{ targetId: '6', type: 'FS' }],
   },
   {

--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -43,6 +43,10 @@
   --milestone-bg: #52525b;
   --milestone-bg-hover: #3f3f46;
 
+  /* 진행률 */
+  --progress-bg: #a1a1aa;
+  --progress-handle: #52525b;
+
   /* 트랜지션 */
   --transition-fast: 150ms ease;
   --transition-normal: 200ms ease;
@@ -73,6 +77,9 @@
 
   --milestone-bg: #d4d4d8;
   --milestone-bg-hover: #e4e4e7;
+
+  --progress-bg: #52525b;
+  --progress-handle: #a1a1aa;
 }
 
 /* ===== BASE LAYOUT ===== */
@@ -416,8 +423,40 @@
   opacity: 0;
 }
 
+/* ===== PROGRESS ===== */
+.gantt-progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: var(--progress-bg);
+  border-radius: 6px 0 0 6px;
+  pointer-events: none;
+}
+
+.gantt-progress-handle {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  background: var(--background);
+  border: 2px solid var(--progress-handle);
+  border-radius: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  cursor: ew-resize;
+  transition: opacity var(--transition-fast);
+}
+
+.gantt-task-bar:hover .gantt-progress-handle,
+.gantt-progress-handle.dragging {
+  opacity: 1;
+}
+
 /* Task Name */
 .gantt-task-name {
+  position: relative;
   flex: 1;
   padding: 0 14px;
   font-family: inherit;

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -8,6 +8,7 @@ import {
   NODE_HEIGHT,
 } from "constants/gantt";
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
+import { useGanttProgressDrag } from "hooks/useGanttProgressDrag";
 import { useRef, useState, useCallback } from "react";
 import { useGanttStore } from "stores/store";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
@@ -43,6 +44,11 @@ export default function GanttBar({
   const labelOutside = finalWidth < MIN_LABEL_INSIDE_WIDTH;
 
   const isMilestone = isMilestoneTask(currentTask);
+
+  // 진행률 (마일스톤은 진행률 없음)
+  const { onProgressPointerDown, progress, isDraggingProgress } =
+    useGanttProgressDrag(currentTask, barRef, onTasksChange);
+  const showProgress = !isMilestone && progress !== null;
 
   // 마우스 위치에 따른 커서 변경 (마일스톤은 리사이즈 없음)
   const handleMouseMove = useCallback(
@@ -141,8 +147,35 @@ export default function GanttBar({
       }}
       role="button"
       tabIndex={0}
-      aria-label={`태스크: ${currentTask.name}`}
+      aria-label={
+        showProgress
+          ? `태스크: ${currentTask.name}, ${progress}% 완료`
+          : `태스크: ${currentTask.name}`
+      }
     >
+      {/* 진행률 채움 + 핸들 */}
+      {showProgress && (
+        <>
+          <div
+            className="gantt-progress-fill"
+            style={{ width: `${progress}%` }}
+          />
+          <div
+            className={`gantt-progress-handle${
+              isDraggingProgress ? " dragging" : ""
+            }`}
+            style={{ left: `${progress}%` }}
+            onPointerDown={onProgressPointerDown}
+            role="slider"
+            tabIndex={-1}
+            aria-label={`${currentTask.name} 진행률`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progress}
+          />
+        </>
+      )}
+
       <span
         className={`gantt-task-name${labelOutside ? " outside" : ""}`}
       >
@@ -153,6 +186,13 @@ export default function GanttBar({
       {isDragging && liveOffset && (
         <div className="gantt-bar-tooltip" role="status" aria-live="polite">
           {getTooltipText(dragMode)}
+        </div>
+      )}
+
+      {/* 진행률 드래그 중 툴팁 */}
+      {isDraggingProgress && (
+        <div className="gantt-bar-tooltip" role="status" aria-live="polite">
+          {progress}%
         </div>
       )}
     </div>

--- a/src/hooks/useGanttProgressDrag.ts
+++ b/src/hooks/useGanttProgressDrag.ts
@@ -1,0 +1,72 @@
+import React, { useRef, useState } from "react";
+import { useGanttStore } from "stores/store";
+import { normalizeProgress, Task, TaskTransformed } from "types/task";
+
+/**
+ * 진행률 핸들 드래그 훅
+ * 드래그 중에는 로컬 값으로 미리보기, pointerup 시 rawTasks에 커밋
+ */
+export function useGanttProgressDrag(
+  task: TaskTransformed,
+  barRef: React.RefObject<HTMLDivElement | null>,
+  onTasksChange?: (updatedTasks: Task[]) => void
+) {
+  const [liveProgress, setLiveProgress] = useState<number | null>(null);
+  const liveProgressRef = useRef<number | null>(null);
+
+  const percentFromPointer = (clientX: number): number | null => {
+    const bar = barRef.current;
+    if (!bar) return null;
+
+    const rect = bar.getBoundingClientRect();
+    if (rect.width === 0) return null;
+
+    const ratio = (clientX - rect.left) / rect.width;
+    return Math.round(Math.min(1, Math.max(0, ratio)) * 100);
+  };
+
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    // 바 이동 드래그와 겹치지 않도록 차단
+    e.stopPropagation();
+    e.preventDefault();
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const percent = percentFromPointer(moveEvent.clientX);
+      if (percent === null) return;
+
+      liveProgressRef.current = percent;
+      setLiveProgress(percent);
+    };
+
+    const handlePointerUp = () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
+      document.removeEventListener("pointercancel", handlePointerUp);
+
+      const percent = liveProgressRef.current;
+      liveProgressRef.current = null;
+      setLiveProgress(null);
+
+      if (percent === null) return;
+
+      const updatedTasks = useGanttStore
+        .getState()
+        .rawTasks.map((t) =>
+          t.id === task.id ? { ...t, progress: percent } : t
+        );
+
+      useGanttStore.getState().setRawTasks(updatedTasks);
+      onTasksChange?.(updatedTasks);
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", handlePointerUp);
+    document.addEventListener("pointercancel", handlePointerUp);
+  };
+
+  return {
+    onProgressPointerDown: onPointerDown,
+    progress: liveProgress ?? normalizeProgress(task.progress),
+    isDraggingProgress: liveProgress !== null,
+  };
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -9,11 +9,19 @@ export interface Task {
   sequence: string;
   /** 태스크 종류 - 'milestone'은 startDate 기준 다이아몬드로 렌더링 (기본 'task') */
   type?: TaskType;
+  /** 진행률 0-100 (%) - 생략 시 진행률 표시 없음 */
+  progress?: number;
   dependencies?: TaskDependency[];
 }
 
 export function isMilestoneTask(task: Pick<Task, 'type'>): boolean {
   return task.type === 'milestone';
+}
+
+/** 진행률을 0-100 범위로 정규화, 값이 없거나 유효하지 않으면 null */
+export function normalizeProgress(progress: number | undefined): number | null {
+  if (typeof progress !== 'number' || Number.isNaN(progress)) return null;
+  return Math.min(100, Math.max(0, progress));
 }
 
 export interface TaskDependency {

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import dayjs from 'utils/dayjs';
-import type { Task } from 'types/task';
+import { normalizeProgress, type Task } from 'types/task';
 import { getSmartGanttPath } from './arrowPath';
 import { processHeaderGroups } from './headerUtils';
 import {
@@ -48,6 +48,16 @@ describe('transformTasks', () => {
     );
     expect(m.barLeft).toBe(32);
     expect(m.barWidth).toBe(1);
+  });
+});
+
+describe('normalizeProgress', () => {
+  it('clamps to 0-100 and rejects missing or NaN values', () => {
+    expect(normalizeProgress(42)).toBe(42);
+    expect(normalizeProgress(-10)).toBe(0);
+    expect(normalizeProgress(150)).toBe(100);
+    expect(normalizeProgress(undefined)).toBeNull();
+    expect(normalizeProgress(Number.NaN)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #22. Stacked on #62.

- `Task.progress?: number` (0-100) with a `normalizeProgress()` helper that clamps to range and treats missing/NaN as "no progress" — unit tested.
- A fill renders inside the bar up to the percentage; omitting `progress` leaves the bar exactly as before.
- New `useGanttProgressDrag` hook: a circular handle at the fill edge (revealed on hover) drags to set the value in whole percent, shows the live percentage in the existing tooltip style, and commits through `setRawTasks` + `onTasksChange` on pointerup. The handle stops propagation so it never starts a bar move.
- Milestones have no progress. `aria-label` on the bar now includes the percentage, and the handle exposes `role="slider"` with min/max/now.
- Demo data gained progress values on the first eight tasks.

Verified by driving a real pointer drag in the demo: handle at 100% dragged to 25% shows "25%" live and the committed fill stays at 25% after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)