### PR TITLE
fix: drag correctness (clamp, cancel, pointer filtering, re-render churn)

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -356,6 +356,7 @@
 /* ===== TASK BAR ===== */
 .gantt-task-bar {
   position: relative;
+  touch-action: none;
   z-index: 10;
   display: flex;
   align-items: center;
@@ -482,6 +483,7 @@
 /* ===== MILESTONE ===== */
 .gantt-milestone {
   position: relative;
+  touch-action: none;
   z-index: 10;
   display: flex;
   align-items: center;

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -13,6 +13,7 @@ export type DragMode = "bar" | "left" | "right";
 
 interface DragContext {
   mode: DragMode;
+  pointerId: number;
   initialClientX: number;
   initialStartDate: dayjs.Dayjs;
   initialEndDate: dayjs.Dayjs;
@@ -65,11 +66,17 @@ export function useGanttBarDrag(
   };
 
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    // 주 포인터의 왼쪽 버튼만 드래그 시작 (우클릭/보조 터치는 무시)
+    if (!e.isPrimary || e.button !== 0) return;
+    // 이미 드래그 중이면 두 번째 포인터를 무시
+    if (dragContextRef.current) return;
+
     const mode = detectDragMode(e);
     dragModeRef.current = mode;
 
     dragContextRef.current = {
       mode,
+      pointerId: e.pointerId,
       initialClientX: e.clientX,
       initialStartDate: dayjs(task.startDate),
       initialEndDate: dayjs(task.endDate),
@@ -86,11 +93,20 @@ export function useGanttBarDrag(
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const ctx = dragContextRef.current;
-      if (!ctx) return;
+      if (!ctx || moveEvent.pointerId !== ctx.pointerId) return;
 
       const deltaX = moveEvent.clientX - ctx.initialClientX;
-      const steps = Math.round(deltaX / ctx.basePxPerDragStep);
-      
+      const rawSteps = Math.round(deltaX / ctx.basePxPerDragStep);
+
+      // 최소 한 스텝 너비는 남기도록 스텝 자체를 클램프
+      // (미리보기만 막고 커밋은 그대로 두면 end < start 로 커밋된다)
+      const maxShrinkSteps = Math.floor(
+        (ctx.initialBarWidth - ctx.basePxPerDragStep) / ctx.basePxPerDragStep
+      );
+      let steps = rawSteps;
+      if (ctx.mode === "left") steps = Math.min(rawSteps, maxShrinkSteps);
+      if (ctx.mode === "right") steps = Math.max(rawSteps, -maxShrinkSteps);
+
       if (steps === ctx.dragSteps) return;
       ctx.dragSteps = steps;
 
@@ -116,10 +132,6 @@ export function useGanttBarDrag(
           newEndDate = ctx.initialEndDate;
           offsetX = draggedPx;
           offsetWidth = -draggedPx;
-          
-          if (ctx.initialBarWidth + offsetWidth < ctx.basePxPerDragStep) {
-            return;
-          }
           break;
 
         case "right":
@@ -127,10 +139,6 @@ export function useGanttBarDrag(
           newEndDate = ctx.initialEndDate.add(totalMinutes, "minute");
           offsetX = 0;
           offsetWidth = draggedPx;
-          
-          if (ctx.initialBarWidth + offsetWidth < ctx.basePxPerDragStep) {
-            return;
-          }
           break;
 
         default:
@@ -147,21 +155,41 @@ export function useGanttBarDrag(
       useGanttStore.getState().setDragOffset(ctx.taskId, offset);
     };
 
-    const handlePointerUp = () => {
+    const detachListeners = () => {
       document.removeEventListener("pointermove", handlePointerMove);
       document.removeEventListener("pointerup", handlePointerUp);
-      document.removeEventListener("pointercancel", handlePointerUp);
+      document.removeEventListener("pointercancel", handlePointerCancel);
+    };
 
+    const endDrag = (taskId: string) => {
+      dragContextRef.current = null;
+      dragModeRef.current = null;
+      useGanttStore.getState().setCurrentTask(null);
+      useGanttStore.getState().clearDragOffset(taskId);
+    };
+
+    // 브라우저가 제스처를 취소한 경우(스크롤 인계, 멀티터치 등)는 커밋하지 않고 되돌린다
+    const handlePointerCancel = (cancelEvent: PointerEvent) => {
       const ctx = dragContextRef.current;
+      if (ctx && cancelEvent.pointerId !== ctx.pointerId) return;
+
+      detachListeners();
+      if (ctx) endDrag(ctx.taskId);
+    };
+
+    const handlePointerUp = (upEvent: PointerEvent) => {
+      const pending = dragContextRef.current;
+      if (pending && upEvent.pointerId !== pending.pointerId) return;
+
+      detachListeners();
+
+      const ctx = pending;
       if (!ctx) {
         return;
       }
 
       if (ctx.dragSteps === 0) {
-        dragContextRef.current = null;
-        dragModeRef.current = null;
-        useGanttStore.getState().setCurrentTask(null);
-        useGanttStore.getState().clearDragOffset(ctx.taskId);
+        endDrag(ctx.taskId);
         return;
       }
 
@@ -200,15 +228,17 @@ export function useGanttBarDrag(
       useGanttStore.getState().setRawTasks(updatedTasks);
       onTasksChangeRef.current?.(updatedTasks);
 
+      // dragOffset은 여기서 지우지 않는다 - 새 transformedTasks가 계산되기 전에
+      // 지우면 바가 한 프레임 동안 원위치로 돌아갔다 오는 깜빡임이 생긴다.
+      // Gantt의 타임라인 재계산 이펙트가 새 위치와 함께 한 번에 정리한다.
       dragContextRef.current = null;
       dragModeRef.current = null;
       useGanttStore.getState().setCurrentTask(null);
-      useGanttStore.getState().clearDragOffset(ctx.taskId);
     };
 
     document.addEventListener("pointermove", handlePointerMove);
     document.addEventListener("pointerup", handlePointerUp);
-    document.addEventListener("pointercancel", handlePointerUp);
+    document.addEventListener("pointercancel", handlePointerCancel);
   };
 
   return { 

--- a/src/hooks/useGanttSelectors.ts
+++ b/src/hooks/useGanttSelectors.ts
@@ -4,6 +4,9 @@ import { useGanttStore } from "stores/store";
 /**
  * Gantt 스토어에서 필요한 상태와 액션을 선택하는 훅
  * shallow 비교를 사용하여 불필요한 리렌더링 방지
+ *
+ * 드래그 프레임마다 바뀌는 dragOffsets/currentTask는 여기서 구독하지 않는다.
+ * (필요한 컴포넌트에서 개별 구독 - 차트 전체가 매 프레임 리렌더되는 것을 방지)
  */
 export function useGanttSelectors() {
   return useGanttStore(
@@ -13,21 +16,16 @@ export function useGanttSelectors() {
       transformedTasks: state.transformedTasks,
       bottomRowCells: state.bottomRowCells,
       selectedScale: state.selectedScale,
-      currentTask: state.currentTask,
-      dragOffsets: state.dragOffsets,
 
       // 액션
       setRawTasks: state.setRawTasks,
       setTransformedTasks: state.setTransformedTasks,
       setBottomRowCells: state.setBottomRowCells,
       setSelectedScale: state.setSelectedScale,
-      setCurrentTask: state.setCurrentTask,
-      setDragOffset: state.setDragOffset,
-      clearDragOffset: state.clearDragOffset,
+      clearAllDragOffsets: state.clearAllDragOffsets,
 
       // 계산된 값
       getTotalWidth: state.getTotalWidth,
-      getCurrentDragOffset: state.getCurrentDragOffset,
     }))
   );
 }

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -57,6 +57,7 @@ function Gantt({
     setTransformedTasks,
     setBottomRowCells,
     setSelectedScale,
+    clearAllDragOffsets,
     getTotalWidth,
   } = useGanttSelectors();
 
@@ -102,7 +103,15 @@ function Gantt({
 
     setBottomRowCells(bottomCells);
     setTransformedTasks(transformed);
-  }, [rawTasks, selectedScale, setBottomRowCells, setTransformedTasks]);
+    // 새 위치가 준비된 시점에 드래그 오프셋 정리 - 드롭 시 한 프레임 깜빡임 방지
+    clearAllDragOffsets();
+  }, [
+    rawTasks,
+    selectedScale,
+    setBottomRowCells,
+    setTransformedTasks,
+    clearAllDragOffsets,
+  ]);
 
   // 스케일 변경 핸들러
   const handleScaleChange = (scale: GanttScaleKey) => {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -23,6 +23,7 @@ interface GanttState {
   setTransformedTasks: (tasks: TaskTransformed[]) => void;
   setDragOffset: (id: string, offset: GanttDragOffset) => void;
   clearDragOffset: (id: string) => void;
+  clearAllDragOffsets: () => void;
 
   // 계산된 셀렉터
   getCurrentDragOffset: (taskId: string) => GanttDragOffset | null;
@@ -54,6 +55,20 @@ export const useGanttStore = create<GanttState>()(
         set((state) => {
           const { [id]: _removed, ...rest } = state.dragOffsets;
           return { dragOffsets: rest };
+        }),
+
+      // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
+      // 타임라인 재계산에 휩쓸려 사라지지 않도록
+      clearAllDragOffsets: () =>
+        set((state) => {
+          const activeId = state.currentTask?.id;
+          const keys = Object.keys(state.dragOffsets);
+          if (!keys.length) return state;
+          if (!activeId || !state.dragOffsets[activeId]) {
+            return { dragOffsets: {} };
+          }
+          if (keys.length === 1) return state;
+          return { dragOffsets: { [activeId]: state.dragOffsets[activeId] } };
         }),
 
       getCurrentDragOffset: (taskId: string) => {


### PR DESCRIPTION
Closes #64, #65, #70, #74, #75.

**#64 — resize committed steps the preview had rejected.** The min-width guard early-returned out of the preview update but `ctx.dragSteps` had already advanced, so releasing committed the unclamped value: dragging a right edge far enough left produced `endDate < startDate`, a range the user never saw. The step count is now clamped before it is stored, so preview and commit are always the same number.

**#65 — `pointercancel` committed the drag.** It shared a handler with `pointerup`. A browser-aborted gesture (touch scroll takeover, pinch, orientation change) silently wrote a date change and fired `onTasksChange`. Cancel now has its own handler that reverts. `.gantt-task-bar` and `.gantt-milestone` also set `touch-action: none` so intentional touch drags aren't hijacked by native scrolling in the first place.

**#70 — any pointer could drive or end a drag.** Right-click started a real drag (and on macOS the context menu swallowed the release, leaving it stuck); a second finger's move drove the first finger's math, and its release committed the half-finished drag. `onPointerDown` now requires `isPrimary` and button 0 and ignores a second start, and move/up/cancel ignore events from other `pointerId`s.

**#75 — one-frame revert flicker on drop.** The drag offset was cleared before the recomputed task positions existed, so the bar jumped back for a frame. The offset now survives until the timeline effect publishes the new positions, and both land in one render. The clear deliberately preserves the offset of a drag already in progress — otherwise dropping and immediately grabbing another bar wipes the new drag (verified: that exact sequence broke before this guard).

**#74 — whole chart re-rendered every drag frame.** `useGanttSelectors` subscribed to `dragOffsets` and `currentTask`, which the parent never reads; each pointermove re-rendered every row. Those subscriptions are gone — the components that need them subscribe individually.

Verified in the demo by driving real pointer events: a 400px shrink drag on a 107px bar clamps to 43px during the drag and commits 43px (previously it committed an inverted range), guides appear and clear correctly, and a bar-move drag still commits normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)