### PR TITLE
fix: correct header tick labels and group alignment (#67, #72, #73, #55)

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -253,9 +253,12 @@
 }
 
 .gantt-top-group {
+  --top-group-inset: 16px;
+  /* padding이 너비에 포함되어야 타임라인 셀과 경계가 맞음 */
+  box-sizing: border-box;
   display: flex;
   align-items: center;
-  padding: 0 16px;
+  padding: 0 var(--top-group-inset);
   font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -263,13 +266,10 @@
   color: var(--foreground);
 }
 
-.gantt-top-group.sticky {
-  position: sticky;
-  left: 0;
-  z-index: 1;
-}
-
+/* 그룹 자체가 아닌 라벨만 고정 - 다음 그룹이 들어오면 밀려나며 가리지 않음 */
 .gantt-top-group-label {
+  position: sticky;
+  left: var(--top-group-inset);
   margin: 0;
   padding: 0;
   white-space: nowrap;
@@ -581,8 +581,8 @@
   }
 
   .gantt-top-group {
+    --top-group-inset: 12px;
     font-size: 12px;
-    padding: 0 12px;
   }
 
   .gantt-bottom-cell {

--- a/src/components/GanttChartHeader.tsx
+++ b/src/components/GanttChartHeader.tsx
@@ -1,14 +1,15 @@
 import { GANTT_SCALE_CONFIG } from "constants/gantt";
-import React, { useEffect, useMemo, useState, useCallback } from "react";
+import React, { useMemo } from "react";
 import { GanttBottomRowCell, GanttScaleKey } from "types/gantt";
-import { processHeaderGroups } from "utils/headerUtils";
+import { mergeHeaderGroups } from "utils/headerUtils";
 import { createTopHeaderGroups } from "utils/timeline";
 
 interface GanttChartHeaderProps {
   bottomRowCells: GanttBottomRowCell[];
   selectedScale: GanttScaleKey;
   width: number;
-  scrollRef: React.RefObject<HTMLDivElement | null>;
+  /** 사용하지 않음 - 상단 그룹 라벨 고정은 CSS sticky로 처리 */
+  scrollRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -19,42 +20,15 @@ function GanttChartHeader({
   bottomRowCells,
   selectedScale,
   width,
-  scrollRef,
 }: GanttChartHeaderProps) {
   const config = GANTT_SCALE_CONFIG[selectedScale];
-  const [stickyIndex, setStickyIndex] = useState(0);
 
-  // 헤더 그룹 생성 및 처리 (memoized)
-  const groupsWithPositions = useMemo(() => {
-    const topGroups = createTopHeaderGroups(bottomRowCells, selectedScale);
-    return processHeaderGroups(topGroups);
-  }, [bottomRowCells, selectedScale]);
-
-  // 스크롤 이벤트 핸들러
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const scrollLeft = el.scrollLeft;
-
-    // 가로 스크롤 시 sticky 헤더 인덱스 업데이트
-    for (let i = groupsWithPositions.length - 1; i >= 0; i--) {
-      if (scrollLeft >= groupsWithPositions[i].left) {
-        setStickyIndex(i);
-        break;
-      }
-    }
-  }, [groupsWithPositions, scrollRef]);
-
-  // 스크롤 리스너 등록
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    el.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-    return () => el.removeEventListener("scroll", handleScroll);
-  }, [handleScroll, scrollRef]);
+  // 헤더 그룹 생성 및 병합 (memoized)
+  const topGroups = useMemo(
+    () =>
+      mergeHeaderGroups(createTopHeaderGroups(bottomRowCells, selectedScale)),
+    [bottomRowCells, selectedScale]
+  );
 
   return (
     <header className="gantt-header" style={{ width: `${width}px` }}>
@@ -62,21 +36,15 @@ function GanttChartHeader({
         {/* 상단 헤더 그룹 */}
         <div className="gantt-top-header">
           <div className="gantt-top-groups">
-            {groupsWithPositions.map((group, idx) => {
-              const isSticky = idx === stickyIndex;
-              return (
-                <div
-                  key={`${group.label}-${idx}`}
-                  className={`gantt-top-group${isSticky ? " sticky" : ""}`}
-                  style={{
-                    width: `${group.widthPx}px`,
-                    ...(isSticky && { left: 0 }),
-                  }}
-                >
-                  <p className="gantt-top-group-label">{group.label}</p>
-                </div>
-              );
-            })}
+            {topGroups.map((group, idx) => (
+              <div
+                key={`${group.label}-${idx}`}
+                className="gantt-top-group"
+                style={{ width: `${group.widthPx}px` }}
+              >
+                <p className="gantt-top-group-label">{group.label}</p>
+              </div>
+            ))}
           </div>
         </div>
 

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -15,11 +15,11 @@ export const MILESTONE_SIZE = 16;
 /** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
 export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
-/** 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) */
+/** 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제 */
 export const DATE_FORMATS: Record<GanttScaleKey, string> = {
-  day: 'MMM D, h A',
-  week: 'MMM D',
-  month: 'MMM D',
+  day: 'MMM D, YYYY HH:mm',
+  week: 'MMM D, YYYY',
+  month: 'MMM D, YYYY',
   year: 'MMM YYYY',
 };
 
@@ -31,8 +31,9 @@ export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
     dragStepUnit: 'hour',
     dragStepAmount: 1,
     basePxPerDragStep: 32,
-    formatTickLabel: (d) => d.format('hh'),
-    formatHeaderLabel: (d) => d.format('MMM D'),
+    // 12시간제는 오전/오후 구분이 없어 하루에 같은 라벨이 두 번 나옴 - 24시간제 사용
+    formatTickLabel: (d) => d.format('HH'),
+    formatHeaderLabel: (d) => d.format('MMM D, YYYY'),
   },
   week: {
     labelUnit: 'month', 
@@ -42,7 +43,7 @@ export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
     dragStepAmount: 6,
     basePxPerDragStep: 54,
     formatTickLabel: (d) => d.format('D'),
-    formatHeaderLabel: (d) => d.format('MMM'),
+    formatHeaderLabel: (d) => d.format('MMM YYYY'),
   },
   month: {
     labelUnit: 'month',
@@ -55,13 +56,14 @@ export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
     formatHeaderLabel: (d) => d.format('MMM YYYY'),
   },
   year: {
-    labelUnit: 'month',
+    // 틱이 월 단위라 상단은 연도, 하단은 월 - 하단에 일(D)을 쓰면 항상 '1'만 나옴
+    labelUnit: 'year',
     tickUnit: 'month',
     unitPerTick: 1,
     dragStepUnit: 'day',
     dragStepAmount: 7,
     basePxPerDragStep: 28,
-    formatTickLabel: (d) => d.format('D'),
-    formatHeaderLabel: (d) => d.format('MMM YYYY'),
+    formatTickLabel: (d) => d.format('MMM'),
+    formatHeaderLabel: (d) => d.format('YYYY'),
   },
 };

--- a/src/utils/headerUtils.ts
+++ b/src/utils/headerUtils.ts
@@ -1,9 +1,5 @@
 import { GanttTopHeaderGroup } from 'types/gantt';
 
-export interface HeaderGroupWithPosition extends GanttTopHeaderGroup {
-  left: number;
-}
-
 /**
  * 동일한 라벨을 가진 연속된 그룹들을 병합
  * 같은 월/년도 등의 연속된 셀들을 하나의 그룹으로 합침
@@ -26,30 +22,3 @@ export function mergeHeaderGroups(
 
   return merged;
 }
-
-/**
- * 그룹들에 왼쪽 위치(left) 값 추가
- * 스크롤 시 sticky 헤더 위치 계산에 사용
- */
-export function addLeftPositions(
-  groups: GanttTopHeaderGroup[]
-): HeaderGroupWithPosition[] {
-  let offset = 0;
-  return groups.map((group) => {
-    const groupWithLeft = { ...group, left: offset };
-    offset += group.widthPx;
-    return groupWithLeft;
-  });
-}
-
-/**
- * 헤더 그룹을 병합하고 위치 정보 추가
- * mergeHeaderGroups와 addLeftPositions를 한 번에 수행
- */
-export function processHeaderGroups(
-  groups: GanttTopHeaderGroup[]
-): HeaderGroupWithPosition[] {
-  const merged = mergeHeaderGroups(groups);
-  return addLeftPositions(merged);
-}
-

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import dayjs from 'utils/dayjs';
+import { DATE_FORMATS, GANTT_SCALE_CONFIG } from 'constants/gantt';
 import { normalizeProgress, type Task } from 'types/task';
 import { getSmartGanttPath } from './arrowPath';
-import { processHeaderGroups } from './headerUtils';
+import { mergeHeaderGroups } from './headerUtils';
 import {
   calculateDateOffsetPx,
   calculateDateOffsets,
@@ -105,6 +106,31 @@ describe('calculateDateOffsetPx', () => {
   });
 });
 
+describe('GANTT_SCALE_CONFIG labels', () => {
+  const afternoon = dayjs('2025-09-01T15:00');
+
+  it('labels day ticks in 24-hour time so AM and PM differ', () => {
+    expect(GANTT_SCALE_CONFIG.day.formatTickLabel?.(dayjs('2025-09-01T09:00'))).toBe('09');
+    expect(GANTT_SCALE_CONFIG.day.formatTickLabel?.(afternoon)).toBe('15');
+    expect(GANTT_SCALE_CONFIG.day.formatTickLabel?.(dayjs('2025-09-01T00:00'))).toBe('00');
+  });
+
+  it('labels year-scale month ticks with the month, not the day of month', () => {
+    expect(GANTT_SCALE_CONFIG.year.formatTickLabel?.(afternoon)).toBe('Sep');
+    expect(GANTT_SCALE_CONFIG.week.formatTickLabel?.(afternoon)).toBe('1');
+    expect(GANTT_SCALE_CONFIG.month.formatTickLabel?.(afternoon)).toBe('1');
+  });
+
+  it('shows the year in every header label and drag tooltip format', () => {
+    expect(GANTT_SCALE_CONFIG.day.formatHeaderLabel?.(afternoon)).toBe('Sep 1, 2025');
+    expect(GANTT_SCALE_CONFIG.week.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
+    expect(GANTT_SCALE_CONFIG.month.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
+    expect(GANTT_SCALE_CONFIG.year.formatHeaderLabel?.(afternoon)).toBe('2025');
+    expect(afternoon.format(DATE_FORMATS.day)).toBe('Sep 1, 2025 15:00');
+    expect(afternoon.format(DATE_FORMATS.week)).toBe('Sep 1, 2025');
+  });
+});
+
 describe('createTopHeaderGroups', () => {
   it('groups daily ticks into month headers', () => {
     expect(
@@ -115,14 +141,23 @@ describe('createTopHeaderGroups', () => {
     ]);
     expect(createTopHeaderGroups([], 'month')).toEqual([]);
   });
+
+  it('groups monthly ticks into year headers at year scale', () => {
+    expect(
+      createTopHeaderGroups(ticks('2025-11-01', '2025-12-01', '2026-01-01'), 'year'),
+    ).toMatchObject([
+      { label: '2025', widthPx: 64 },
+      { label: '2026', widthPx: 32 },
+    ]);
+  });
 });
 
-describe('processHeaderGroups', () => {
-  it('merges adjacent equal labels without mutating input, then assigns left offsets', () => {
+describe('mergeHeaderGroups', () => {
+  it('merges adjacent equal labels without mutating input', () => {
     const input = [group('Jan', 10), group('Jan', 20), group('Feb', 5)];
-    expect(processHeaderGroups(input)).toMatchObject([
-      { label: 'Jan', widthPx: 30, left: 0 },
-      { label: 'Feb', widthPx: 5, left: 30 },
+    expect(mergeHeaderGroups(input)).toMatchObject([
+      { label: 'Jan', widthPx: 30 },
+      { label: 'Feb', widthPx: 5 },
     ]);
     expect(input[0].widthPx).toBe(10);
   });


### PR DESCRIPTION
Four header bugs, all visible the moment you open the chart.

### Year scale bottom row was a row of "1"s (#67)

The year scale ticks by month, but its tick formatter printed the day of month (`D`). Every tick starts on the 1st, so the whole bottom row read "1 1 1 1 …" and carried no information. The year scale now labels the top row with the year (`YYYY`, grouped by `labelUnit: 'year'`) and the bottom row with the month (`MMM`), instead of repeating "MMM YYYY" on top and nothing useful below.

### Ambiguous and year-less tick labels (#72)

The day scale used the zero-padded 12-hour clock with no meridiem, so 09:00 and 21:00 both rendered "09" and midnight and noon both rendered "12". It now uses 24-hour `HH`. Day and week headers also never showed a year anywhere; they now read "Sep 2, 2026" and "Sep 2026". The drag tooltip/guide formats (`DATE_FORMATS`) picked up the same treatment — year included, 24-hour time — since they had the same gap.

### Sticky group label hid the incoming group (#73)

The active top group was pinned with `position: sticky; left: 0` on the whole group cell, and that cell has an opaque full-width background, so once you scrolled ~16px into a month the pinned box painted over the next month's label. The header could show "Sep 2026" while the timeline underneath was well into October, and the correct label only popped in at the boundary.

Now only the inner `.gantt-top-group-label` is sticky, inset by the group's own padding. Sticky positioning clamps it to its group's box, so the outgoing label slides out as the next group arrives — standard push-out behavior — and the incoming label is never covered. This also removed the scroll listener, the `stickyIndex` state, and the `left`-offset helpers in `headerUtils` that existed only to feed it.

### Top groups drifted right of the timeline (#55)

`.gantt-top-group` had `padding: 0 16px` under the default `content-box`, so every group rendered 32px wider than the `widthPx` computed from its cells, and the error accumulated left to right. `box-sizing: border-box` on the group fixes it without a global reset (a separate issue covers box-sizing normalization). The inset is now a local `--top-group-inset` custom property so the padding and the sticky label offset stay in sync, including the 12px value under the mobile media query.

### Verification

`pnpm lint` 0 errors / 4 pre-existing warnings, `pnpm type-check` clean, `pnpm test` 17 passed, `pnpm build` OK.

New unit tests cover the tick and header formatters at all four scales (including 09 vs 15 vs 00 at day scale and "Sep" instead of "1" at year scale) and year-scale grouping in `createTopHeaderGroups`.

Alignment was measured in a headless browser on the demo app: for every top group, its rendered `left` was compared against the rendered `left` of the bottom cell that logically starts it (matched through the model widths React writes as inline styles). Delta was **0.00px at every group on all four scales** — day (157 groups), week, month and year — and each group's rendered width equals its model width exactly (e.g. month: 160/960/992/960/992/992/320). At year scale the bottom row now reads "Apr May Jun … Dec Jan Feb", and the "2027" group starts exactly at the "Jan" cell.

Sticky behavior was measured the same way while scrolling the month scale: at scrollLeft 400 and 900 the pinned "Sep 2026" sits at x=16 while "Oct 2026" is visible at its natural position and is the topmost element at its own center (it was covered before). Across scrollLeft 1020 → 1104 the outgoing label slides from x=-8 to x=-92 while the incoming one arrives at x=16, with a 32px gap between them at every sampled frame — no overlap, no pop-in. No console errors.

Closes #67
Closes #72
Closes #73
Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
