### PR TITLE
fix: dependency arrows follow both ends and render behind bars (#66, #77, #79, #83)

### DIFF
--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -304,7 +304,8 @@
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  /* 배경 레이어 - 화살표/바와 같은 레이어에서 DOM 순서상 가장 먼저 그려진다 */
+  z-index: 0;
   pointer-events: none;
 }
 
@@ -339,7 +340,9 @@
   left: 0;
   width: 100%;
   pointer-events: none;
-  z-index: 5;
+  /* 바 wrapper는 transform 때문에 자체 stacking context라 바의 z-index가 밖으로 안 나온다.
+     화살표를 같은 auto/0 레이어에 두면 DOM 순서상 뒤에 오는 바가 위에 그려진다. */
+  z-index: 0;
 }
 
 .gantt-dependency-arrow {

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -1,86 +1,11 @@
-import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from "constants/gantt";
+import { NODE_HEIGHT } from "constants/gantt";
+import { useId } from "react";
 import { useGanttStore } from "stores/store";
-import { isMilestoneTask, RenderedDependency, TaskTransformed } from "types/task";
-import { getSmartGanttPath } from "utils/arrowPath";
+import { TaskTransformed } from "types/task";
+import { buildDependencies, getSmartGanttPath } from "utils/arrowPath";
 
 interface Props {
   transformedTasks: TaskTransformed[];
-}
-
-// Helper function to calculate arrow coordinates
-function calculateArrowCoords(
-  sourceTask: TaskTransformed,
-  targetTask: TaskTransformed,
-  sourceOffset: { offsetX: number; offsetWidth: number },
-  depType: string
-) {
-  const rowHeight = NODE_HEIGHT;
-  const sourceIndex = sourceTask.order - 1;
-  const targetIndex = targetTask.order - 1;
-
-  // 바 중앙 높이에서 연결 (전통적인 Gantt 차트 스타일)
-  const barCenterY = rowHeight / 2;
-  const fromY = targetIndex * rowHeight + barCenterY;
-  const toY = sourceIndex * rowHeight + barCenterY;
-
-  // 마일스톤은 다이아몬드 꼭짓점에 화살표 연결
-  const targetHalf = isMilestoneTask(targetTask) ? MILESTONE_HALF_DIAGONAL : 0;
-  const sourceHalf = isMilestoneTask(sourceTask) ? MILESTONE_HALF_DIAGONAL : 0;
-
-  const leftX = targetTask.barLeft - targetHalf;
-  const rightX = targetTask.barLeft + (targetHalf || targetTask.barWidth);
-
-  const currentLeftX = sourceTask.barLeft + sourceOffset.offsetX - sourceHalf;
-  const currentRightX = sourceHalf
-    ? sourceTask.barLeft + sourceOffset.offsetX + sourceHalf
-    : sourceTask.barLeft +
-      sourceOffset.offsetX +
-      sourceTask.barWidth +
-      sourceOffset.offsetWidth;
-
-  // 의존성 타입에 따른 X 좌표 설정
-  // FS: 선행 태스크 우측 → 후행 태스크 좌측
-  // SS: 선행 태스크 좌측 → 후행 태스크 좌측
-  // FF: 선행 태스크 우측 → 후행 태스크 우측
-  // SF: 선행 태스크 좌측 → 후행 태스크 우측
-  const coordinateMap = {
-    FS: [rightX, currentLeftX] as const,
-    SS: [leftX, currentLeftX] as const,
-    FF: [rightX, currentRightX] as const,
-    SF: [leftX, currentRightX] as const,
-  };
-
-  const [fromX, toX] = coordinateMap[depType as keyof typeof coordinateMap];
-
-  return { fromX, fromY, toX, toY };
-}
-
-// 의존성 배열 빌드
-function buildDependencies(
-  transformedTasks: TaskTransformed[],
-  liveOffsets: Record<string, { offsetX: number; offsetWidth: number }>
-): RenderedDependency[] {
-  const dependencies: RenderedDependency[] = [];
-
-  for (const currentTask of transformedTasks) {
-    const offset = liveOffsets[currentTask.id] ?? { offsetX: 0, offsetWidth: 0 };
-
-    for (const dep of currentTask.dependencies ?? []) {
-      const targetTask = transformedTasks.find((t) => t.id === dep.targetId);
-      if (!targetTask) continue;
-
-      const { fromX, fromY, toX, toY } = calculateArrowCoords(
-        currentTask,
-        targetTask,
-        offset,
-        dep.type
-      );
-
-      dependencies.push({ ...dep, fromX, fromY, toX, toY });
-    }
-  }
-
-  return dependencies;
 }
 
 export default function GanttDependencyArrows({
@@ -88,6 +13,11 @@ export default function GanttDependencyArrows({
 }: Props) {
   const liveOffsets = useGanttStore((store) => store.dragOffsets);
   const dependencies = buildDependencies(transformedTasks, liveOffsets);
+
+  // marker id는 문서 전역이라 인스턴스마다 고유해야 차트를 여러 개 띄워도 안 섞인다
+  // useId 값에는 url(#...) 참조에 부적합한 문자가 섞이므로 영숫자만 남긴다
+  const instanceId = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const arrowheadId = `gantt-arrowhead-${instanceId}`;
 
   return (
     <svg
@@ -98,7 +28,7 @@ export default function GanttDependencyArrows({
     >
       <defs>
         <marker
-          id="arrowhead"
+          id={arrowheadId}
           markerWidth="5"
           markerHeight="5"
           refX="4.5"
@@ -123,7 +53,7 @@ export default function GanttDependencyArrows({
             dep.toX,
             dep.toY
           )}
-          markerEnd="url(#arrowhead)"
+          markerEnd={`url(#${arrowheadId})`}
           fill="none"
         />
       ))}

--- a/src/utils/arrowPath.ts
+++ b/src/utils/arrowPath.ts
@@ -1,3 +1,18 @@
+import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from "constants/gantt";
+import {
+  isMilestoneTask,
+  RenderedDependency,
+  TaskTransformed,
+} from "types/task";
+
+/** 드래그 중인 태스크의 라이브 오프셋 (드래그 중이 아니면 0) */
+export interface DragOffset {
+  offsetX: number;
+  offsetWidth: number;
+}
+
+const NO_OFFSET: DragOffset = { offsetX: 0, offsetWidth: 0 };
+
 /**
  * Returns the path string for an SVG <path> element for various dependency types.
  * @param dependencyType - One of 'FS', 'FF', 'SF', 'SS' (with a fallback).
@@ -283,4 +298,108 @@ export function getSmartGanttPath(
       // Fallback: simple line
       return `${initialPath} L ${endX} ${endY}`;
   }
+}
+
+/**
+ * 태스크 양 끝의 화살표 앵커 X 좌표.
+ * 드래그 중이면 해당 태스크의 라이브 오프셋을 반영하고,
+ * 마일스톤은 다이아몬드 좌/우 꼭짓점에 연결한다.
+ */
+function anchorX(task: TaskTransformed, offset: DragOffset) {
+  const half = isMilestoneTask(task) ? MILESTONE_HALF_DIAGONAL : 0;
+  const left = task.barLeft + offset.offsetX;
+
+  return {
+    startX: left - half,
+    endX: half ? left + half : left + task.barWidth + offset.offsetWidth,
+  };
+}
+
+/** 개발 모드에서 타입별로 한 번만 경고 */
+const warnedDepTypes = new Set<string>();
+
+/**
+ * 의존성 하나의 화살표 좌표 계산.
+ * targetTask가 선행(predecessor), sourceTask가 의존성을 소유한 후행(successor).
+ * 알 수 없는 의존성 타입이면 null (해당 화살표만 건너뜀).
+ */
+export function calculateArrowCoords(
+  sourceTask: TaskTransformed,
+  targetTask: TaskTransformed,
+  sourceOffset: DragOffset,
+  targetOffset: DragOffset,
+  depType: string
+) {
+  const rowHeight = NODE_HEIGHT;
+  const sourceIndex = sourceTask.order - 1;
+  const targetIndex = targetTask.order - 1;
+
+  // 바 중앙 높이에서 연결 (전통적인 Gantt 차트 스타일)
+  const barCenterY = rowHeight / 2;
+  const fromY = targetIndex * rowHeight + barCenterY;
+  const toY = sourceIndex * rowHeight + barCenterY;
+
+  // 양쪽 끝 모두 자기 자신의 드래그 오프셋을 반영해야 화살표가 바를 따라온다
+  const from = anchorX(targetTask, targetOffset);
+  const to = anchorX(sourceTask, sourceOffset);
+
+  // 의존성 타입에 따른 X 좌표 설정
+  // FS: 선행 태스크 우측 → 후행 태스크 좌측
+  // SS: 선행 태스크 좌측 → 후행 태스크 좌측
+  // FF: 선행 태스크 우측 → 후행 태스크 우측
+  // SF: 선행 태스크 좌측 → 후행 태스크 우측
+  const coordinateMap = {
+    FS: [from.endX, to.startX] as const,
+    SS: [from.startX, to.startX] as const,
+    FF: [from.endX, to.endX] as const,
+    SF: [from.startX, to.endX] as const,
+  };
+
+  // 태스크는 consumer가 넘기는 JSON이라 런타임에 알 수 없는 타입이 올 수 있다
+  const coords: readonly [number, number] | undefined =
+    coordinateMap[depType as keyof typeof coordinateMap];
+
+  if (!coords) {
+    if (import.meta.env.DEV && !warnedDepTypes.has(depType)) {
+      warnedDepTypes.add(depType);
+      console.warn(
+        `[gantt-chart] Unknown dependency type "${depType}" - arrow skipped. Expected one of FS, SS, FF, SF.`
+      );
+    }
+    return null;
+  }
+
+  const [fromX, toX] = coords;
+
+  return { fromX, fromY, toX, toY };
+}
+
+/** 의존성 배열 빌드 */
+export function buildDependencies(
+  transformedTasks: TaskTransformed[],
+  liveOffsets: Record<string, DragOffset>
+): RenderedDependency[] {
+  const dependencies: RenderedDependency[] = [];
+
+  for (const currentTask of transformedTasks) {
+    const sourceOffset = liveOffsets[currentTask.id] ?? NO_OFFSET;
+
+    for (const dep of currentTask.dependencies ?? []) {
+      const targetTask = transformedTasks.find((t) => t.id === dep.targetId);
+      if (!targetTask) continue;
+
+      const coords = calculateArrowCoords(
+        currentTask,
+        targetTask,
+        sourceOffset,
+        liveOffsets[targetTask.id] ?? NO_OFFSET,
+        dep.type
+      );
+      if (!coords) continue;
+
+      dependencies.push({ ...dep, ...coords });
+    }
+  }
+
+  return dependencies;
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import dayjs from 'utils/dayjs';
-import { normalizeProgress, type Task } from 'types/task';
-import { getSmartGanttPath } from './arrowPath';
+import { MILESTONE_HALF_DIAGONAL, NODE_HEIGHT } from 'constants/gantt';
+import { normalizeProgress, type Task, type TaskTransformed } from 'types/task';
+import { buildDependencies, getSmartGanttPath } from './arrowPath';
 import { processHeaderGroups } from './headerUtils';
 import {
   calculateDateOffsetPx,
@@ -141,6 +142,80 @@ describe('getSmartGanttPath', () => {
   it('falls back for off-screen rows and unknown dependency types', () => {
     expect(getSmartGanttPath('FS', 10, 5, 110, -3)).toBe('M 10 5 h 50');
     expect(getSmartGanttPath('XX', 0, 0, 10, 20)).toBe('M 0 0 L 10 20');
+  });
+});
+
+describe('buildDependencies', () => {
+  // A(order 1) is the predecessor, B(order 2) owns the FS dependency on A.
+  const bar = (
+    id: string,
+    order: number,
+    barLeft: number,
+    extra: Partial<TaskTransformed> = {},
+  ): TaskTransformed => ({
+    ...task(id, `${order}`),
+    barLeft,
+    barWidth: 64,
+    depth: 0,
+    order,
+    originalOrder: order,
+    ...extra,
+  });
+  const chain = (extra: Partial<TaskTransformed> = {}) => [
+    bar('a', 1, 100, extra),
+    bar('b', 2, 300, { dependencies: [{ targetId: 'a', type: 'FS' }] }),
+  ];
+  const center = NODE_HEIGHT / 2;
+
+  it('anchors an FS arrow from the predecessor end to the successor start', () => {
+    expect(buildDependencies(chain(), {})).toEqual([
+      { targetId: 'a', type: 'FS', fromX: 164, fromY: center, toX: 300, toY: NODE_HEIGHT + center },
+    ]);
+  });
+
+  it('follows the live offset of whichever end is being dragged', () => {
+    // 선행(A)을 드래그하면 화살표 시작점이 따라와야 한다 (#66)
+    expect(
+      buildDependencies(chain(), { a: { offsetX: 32, offsetWidth: 0 } })[0],
+    ).toMatchObject({ fromX: 196, toX: 300 });
+    // 선행의 우측 리사이즈도 마찬가지
+    expect(
+      buildDependencies(chain(), { a: { offsetX: 0, offsetWidth: 32 } })[0],
+    ).toMatchObject({ fromX: 196, toX: 300 });
+    // 후행(B)을 드래그하면 도착점만 움직인다
+    expect(
+      buildDependencies(chain(), { b: { offsetX: -32, offsetWidth: 0 } })[0],
+    ).toMatchObject({ fromX: 164, toX: 268 });
+  });
+
+  it('anchors milestones at the diamond vertices, offset included', () => {
+    const [dep] = buildDependencies(chain({ type: 'milestone', barWidth: 1 }), {
+      a: { offsetX: 32, offsetWidth: 0 },
+    });
+    expect(dep.fromX).toBe(132 + MILESTONE_HALF_DIAGONAL);
+  });
+
+  it('skips an unrecognized dependency type instead of throwing, warning once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // consumer가 넘기는 JSON에는 타입 밖의 값이 올 수 있다
+    const unknownDep = [
+      { targetId: 'a', type: 'fs' },
+    ] as unknown as TaskTransformed['dependencies'];
+    const tasks = [
+      bar('a', 1, 100),
+      bar('b', 2, 300, { dependencies: unknownDep }),
+      bar('c', 3, 500, { dependencies: unknownDep }),
+    ];
+
+    expect(buildDependencies(tasks, {})).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('skips dependencies pointing at a task that is not in the chart', () => {
+    expect(
+      buildDependencies([bar('b', 1, 300, { dependencies: [{ targetId: 'gone', type: 'FS' }] })], {}),
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Four dependency-arrow bugs, all in the arrow rendering path. Stacked on `fix/drag-correctness/64`.

## Arrows froze at the predecessor end during a drag (#66)

`calculateArrowCoords` looked up the live drag offset for the task that *owns* the dependency (the successor) and fed it into both of that task's anchors, but read the predecessor's anchors straight off `barLeft`/`barWidth`. Grab any bar that something else depends on, and its bar moved while the arrow tail stayed glued to the old position until pointer-up. Since almost every bar is someone's predecessor, this showed up on nearly every drag.

Both ends now resolve their own offset from `dragOffsets`, through one shared `anchorX` helper. That helper also keeps the milestone behaviour that was already there: a milestone anchors at its diamond vertices (`MILESTONE_HALF_DIAGONAL`) rather than at bar edges, and it now does so with the drag offset applied.

Verified in the browser: with task 1 (the target of task 2's FS dependency) held mid-drag, the rendered path's origin moved from `M 186.66…` to `M 634.66…`, matching `barLeft + barWidth + offsetX` from the store, and returned to `M 186.66…` on drop.

## An unknown dependency type white-screened the chart (#77)

`coordinateMap[depType]` returns `undefined` for anything outside FS/SS/FF/SF, and `const [fromX, toX] = undefined` throws during render — with no error boundary, that unmounted the whole Gantt. Tasks are consumer-supplied JSON, so a lowercase `'fs'` from an API was enough to take the chart down.

An unrecognized type now returns `null` and `buildDependencies` skips that one arrow. In development it also logs one warning per unknown type. Verified live by pushing `{ targetId: '1', type: 'fs' }` into the store: the chart kept rendering, the arrow count dropped 51 → 50, one console warning, no page error.

## Arrows painted over task bars (#79)

Each bar sits in a wrapper div positioned with `transform: translateY(...)`. The transform makes the wrapper a stacking context, so `.gantt-task-bar { z-index: 10 }` could not lift the bar past the arrow SVG — the wrapper itself stayed at the `auto`/0 layer while the SVG sat at `z-index: 5` and painted on top.

Fixing it from CSS alone (the wrappers are inline-styled in `Gantt.tsx`): the SVG drops to `z-index: 0`, joining the same paint layer as the wrappers, where DOM order decides — and the bars come after the SVG. `.gantt-rows` moves from `1` to `0` for the same reason, so the row background stays below the arrows instead of being lifted above them.

Verified by sampling points along each arrow path, converting to client coordinates, and keeping the ones that land inside a bar. At those points, with the fix the topmost element is the bar (`DIV.gantt-task-bar`, `DIV.gantt-progress-handle`, `DIV.gantt-milestone`); with `z-index: 5` restored it is `path.gantt-dependency-arrow`. Screenshots of the same crop before/after confirm it.

## Arrowhead marker id was document-global (#83)

`<marker id="arrowhead">` is global to the document, so two charts on one page shared the first instance's marker and could get the wrong theme's arrowhead colour. The id is now `gantt-arrowhead-<useId>` and `markerEnd` references it. `useId()` output is stripped to alphanumerics so it is safe inside `url(#…)`. Confirmed in the DOM: `markerId: "gantt-arrowhead-r0"`.

## Notes

`calculateArrowCoords` and `buildDependencies` moved from the component into `utils/arrowPath.ts`, which is where the rest of the arrow geometry lives, so they can be unit tested. The component is now render-only.

## Verification

- `pnpm lint` — 0 errors, 4 pre-existing warnings
- `pnpm type-check` — clean
- `pnpm test` — 18 passed (5 new, covering both-ends offsets, milestone vertices, unknown-type skip + warn-once, missing target)
- `pnpm build` — clean
- Browser checks above on a local dev server

Closes #66
Closes #77
Closes #79
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)