### PR TITLE
fix: predictable tasks prop sync, scale persistence and SSR safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,10 @@ jobs:
       - run: pnpm type-check
       - run: pnpm test
       - run: pnpm build
+      # SSR safety: importing and server-rendering the built package in plain Node
+      # (no DOM globals) must not touch window/document/sessionStorage.
+      - name: SSR import smoke test
+        run: |
+          node --input-type=module -e "const m = await import('@jaeungkim/gantt-chart'); if (typeof m.ReactGanttChart !== 'function') throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (esm)');"
+          node --input-type=commonjs -e "const m = require('@jaeungkim/gantt-chart'); if (typeof m.ReactGanttChart !== 'function') throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (cjs)');"
+          node --input-type=module -e "const { createElement } = await import('react'); const { renderToString } = await import('react-dom/server'); const { ReactGanttChart } = await import('@jaeungkim/gantt-chart'); const html = renderToString(createElement(ReactGanttChart, { tasks: [{ id: '1', name: 'A', startDate: '2025-01-01', endDate: '2025-01-05', parentId: null, sequence: '1' }] })); if (!html.includes('gantt-container')) throw new Error('SSR render produced no chart markup'); console.log('SSR render OK');"

--- a/src/components/ScaleSelector.tsx
+++ b/src/components/ScaleSelector.tsx
@@ -1,4 +1,5 @@
 import { GANTT_SCALE_CONFIG } from "constants/gantt";
+import { useRef } from "react";
 import { GanttScaleKey } from "types/gantt";
 
 interface ScaleSelectorProps {
@@ -16,18 +17,30 @@ export default function ScaleSelector({
   selectedScale,
   onScaleChange,
 }: ScaleSelectorProps) {
-  const handleKeyDown = (e: React.KeyboardEvent, scale: GanttScaleKey) => {
-    const currentIndex = SCALE_OPTIONS.indexOf(scale);
+  // roving tabindex - 탭 대상은 선택된 옵션 하나뿐이므로 방향키로 선택을 옮길 때
+  // 포커스도 함께 옮겨야 다음 키 입력이 새 옵션 기준으로 동작한다
+  const buttonRefs = useRef<Partial<Record<GanttScaleKey, HTMLButtonElement>>>(
+    {}
+  );
 
+  // 기준 인덱스는 눌린 버튼이 아니라 현재 선택된 옵션에서 가져온다
+  const moveSelection = (step: number) => {
+    const currentIndex = SCALE_OPTIONS.indexOf(selectedScale);
+    const nextIndex =
+      (currentIndex + step + SCALE_OPTIONS.length) % SCALE_OPTIONS.length;
+    const nextScale = SCALE_OPTIONS[nextIndex];
+
+    onScaleChange(nextScale);
+    buttonRefs.current[nextScale]?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
-      const nextIndex = (currentIndex + 1) % SCALE_OPTIONS.length;
-      onScaleChange(SCALE_OPTIONS[nextIndex]);
+      moveSelection(1);
     } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
       e.preventDefault();
-      const prevIndex =
-        (currentIndex - 1 + SCALE_OPTIONS.length) % SCALE_OPTIONS.length;
-      onScaleChange(SCALE_OPTIONS[prevIndex]);
+      moveSelection(-1);
     }
   };
 
@@ -43,11 +56,15 @@ export default function ScaleSelector({
           return (
             <button
               key={scale}
+              ref={(el) => {
+                if (el) buttonRefs.current[scale] = el;
+                else delete buttonRefs.current[scale];
+              }}
               type="button"
               className="gantt-scale-button"
               data-active={isActive}
               onClick={() => onScaleChange(scale)}
-              onKeyDown={(e) => handleKeyDown(e, scale)}
+              onKeyDown={handleKeyDown}
               aria-pressed={isActive}
               tabIndex={isActive ? 0 : -1}
             >

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,67 +1,65 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import { GanttTheme } from 'types/gantt';
 
 interface UseResolvedThemeResult {
-  resolvedTheme: 'light' | 'dark';
   containerClassName: string;
   dataTheme: 'light' | 'dark' | undefined;
 }
 
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+const canMatchMedia = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
+const subscribeSystemTheme = (onChange: () => void) => {
+  if (!canMatchMedia()) return () => {};
+
+  const mediaQuery = window.matchMedia(SYSTEM_DARK_QUERY);
+  mediaQuery.addEventListener('change', onChange);
+  return () => mediaQuery.removeEventListener('change', onChange);
+};
+
+const getSystemTheme = (): 'light' | 'dark' | null => {
+  if (!canMatchMedia()) return null;
+  return window.matchMedia(SYSTEM_DARK_QUERY).matches ? 'dark' : 'light';
+};
+
+// 서버 렌더와 하이드레이션 첫 렌더에서는 시스템 설정을 알 수 없다
+const getServerSystemTheme = (): 'light' | 'dark' | null => null;
+
 /**
  * 테마를 해결하고 관련 클래스명과 data 속성을 생성하는 훅
- * 'system' 테마의 경우 시스템 설정을 감지하여 자동 전환
+ *
+ * 'system' 테마는 useSyncExternalStore로 구독한다 - 서버 렌더와 하이드레이션
+ * 첫 렌더에서는 null(테마 클래스 없음)을 쓰고 하이드레이션 이후에 실제 시스템
+ * 설정으로 전환하므로, 하이드레이션 불일치나 잘못된 테마로 고착되는 일이 없다.
  */
 export function useResolvedTheme(
   theme?: GanttTheme,
   baseClassName = 'gantt-container'
 ): UseResolvedThemeResult {
-  // 시스템 테마 상태 (prefers-color-scheme 감지)
-  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() => {
-    if (typeof window !== 'undefined') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-    }
-    return 'light';
-  });
+  // 시스템 테마 (prefers-color-scheme 구독)
+  const systemTheme = useSyncExternalStore(
+    subscribeSystemTheme,
+    getSystemTheme,
+    getServerSystemTheme
+  );
 
-  // 시스템 테마 변경 감지
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleChange = (e: MediaQueryListEvent) => {
-      setSystemTheme(e.matches ? 'dark' : 'light');
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
-
-  // 최종 테마 결정
-  const resolvedTheme = useMemo((): 'light' | 'dark' => {
-    if (!theme || theme === 'system') {
-      return systemTheme;
-    }
-    return theme;
+  // 최종 테마 결정 - theme이 없으면 호스트가 테마를 관리하므로 아무것도 붙이지 않고,
+  // 'system'은 해석되기 전까지 null
+  const resolvedTheme = useMemo((): 'light' | 'dark' | null => {
+    if (!theme) return null;
+    return theme === 'system' ? systemTheme : theme;
   }, [theme, systemTheme]);
 
   // 컨테이너 클래스명 생성
-  const containerClassName = useMemo(() => {
-    const classes = [baseClassName];
-    if (theme) {
-      classes.push(resolvedTheme);
-    }
-    return classes.join(' ');
-  }, [baseClassName, theme, resolvedTheme]);
-
-  // data-theme 속성 값
-  const dataTheme = theme ? resolvedTheme : undefined;
+  const containerClassName = useMemo(
+    () => (resolvedTheme ? `${baseClassName} ${resolvedTheme}` : baseClassName),
+    [baseClassName, resolvedTheme]
+  );
 
   return {
-    resolvedTheme,
     containerClassName,
-    dataTheme,
+    dataTheme: resolvedTheme ?? undefined,
   };
 }
-

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useGanttSelectors } from "hooks/useGanttSelectors";
 import { useGanttVirtualization } from "hooks/useGanttVirtualization";
 import { useResolvedTheme } from "hooks/useResolvedTheme";
+import { readPersistedScale } from "stores/store";
 import { GanttScaleKey, GanttTheme } from "types/gantt";
 import { Task } from "types/task";
 import dayjs from "utils/dayjs";
@@ -16,9 +17,17 @@ import { calculateDateOffsetPx, computeTimelineData } from "utils/timeline";
 const DEFAULT_HEIGHT = 600;
 const DEFAULT_WIDTH = "100%";
 const DEFAULT_SCALE: GanttScaleKey = "month";
+/** 기본 tasks - 매 렌더 새 배열이 생기지 않도록 모듈 스코프에 고정 */
+const EMPTY_TASKS: Task[] = [];
 
 export interface GanttProps {
-  /** 태스크 데이터 배열 */
+  /**
+   * 태스크 데이터 배열
+   *
+   * 내용이 실제로 바뀔 때만 차트에 반영된다. 부모가 같은 데이터를 새 배열로
+   * 다시 넘기는 경우(인라인 리터럴, 비메모 map 등)에는 무시되므로 드래그로
+   * 방금 편집한 결과가 되돌아가지 않는다. 빈 배열을 넘기면 차트가 비워진다.
+   */
   tasks?: Task[];
   /** 태스크 변경 시 호출되는 콜백 */
   onTasksChange?: (updatedTasks: Task[]) => void;
@@ -28,7 +37,13 @@ export interface GanttProps {
   width?: number | string;
   /** 테마 설정 - 'light', 'dark', 또는 'system' */
   theme?: GanttTheme;
-  /** 기본 스케일 설정 */
+  /**
+   * 초기 스케일 설정
+   *
+   * 세션에 저장된 사용자 선택(sessionStorage)이 없을 때만 적용되는 시드 값이다.
+   * 사용자가 스케일을 바꾸면 그 선택이 저장되어 리마운트 시 우선하며,
+   * 마운트 이후의 prop 변경은 무시된다 (`default*` prop 관례).
+   */
   defaultScale?: GanttScaleKey;
   /** 추가 CSS 클래스명 */
   className?: string;
@@ -39,7 +54,7 @@ export interface GanttProps {
  * 가상화를 사용하여 대량의 태스크를 효율적으로 렌더링
  */
 function Gantt({
-  tasks = [],
+  tasks = EMPTY_TASKS,
   onTasksChange,
   height = DEFAULT_HEIGHT,
   width = DEFAULT_WIDTH,
@@ -77,25 +92,32 @@ function Gantt({
     className ? `gantt-container ${className}` : "gantt-container"
   );
 
-  // 초기 스케일 설정
+  // 초기 스케일 설정 - 세션에 저장된 사용자 선택이 있으면 그 값이 defaultScale보다 우선
+  // (마운트 시 1회만. defaultScale은 시드일 뿐이라 이후 변경은 무시한다)
   useEffect(() => {
-    if (defaultScale && defaultScale !== selectedScale) {
-      setSelectedScale(defaultScale);
-    }
+    setSelectedScale(readPersistedScale() ?? defaultScale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 프롭으로 받아 마지막으로 반영한 태스크 데이터의 스냅샷
+  const syncedTasksRef = useRef<string | null>(null);
+
   // 태스크 데이터 동기화
+  // 배열 identity가 아니라 내용이 바뀌었을 때만 스토어를 덮어쓴다.
+  // 부모가 같은 데이터를 새 배열로 다시 넘기는 리렌더는 무시되므로 드래그 편집이
+  // 되돌아가지 않고, 데이터가 실제로 달라지면(빈 배열 포함) 프롭이 이긴다.
+  // (비교는 직렬화 1회 - tasks 배열 identity가 바뀔 때만 돈다. 태스크 수가
+  //  아주 많아 이 비용이 문제가 되면 부모에서 tasks를 memo 하면 된다)
   useEffect(() => {
-    if (tasks.length > 0) {
-      setRawTasks(tasks);
-    }
+    const snapshot = JSON.stringify(tasks);
+    if (snapshot === syncedTasksRef.current) return;
+
+    syncedTasksRef.current = snapshot;
+    setRawTasks(tasks);
   }, [tasks, setRawTasks]);
 
-  // 타임라인 구조 설정
+  // 타임라인 구조 설정 (태스크가 비면 빈 타임라인으로 정리)
   useEffect(() => {
-    if (!rawTasks.length) return;
-
     const { bottomCells, transformedTasks: transformed } = computeTimelineData(
       rawTasks,
       selectedScale

--- a/src/stores/store.test.ts
+++ b/src/stores/store.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import dayjs from 'utils/dayjs';
+// 이 import 자체가 SSR 안전성 회귀 테스트다 - 모듈 스코프에서 sessionStorage를
+// 건드리면 노드 환경(jsdom 없음)에서 파일 로드가 곧바로 실패한다.
+import { readPersistedScale, useGanttStore } from './store';
+
+// 노드 환경에는 sessionStorage가 없으므로 최소 스텁을 심고 쓰기 횟수를 센다
+const writes: Array<[string, string]> = [];
+const stubSessionStorage = () => {
+  const data = new Map<string, string>();
+  writes.length = 0;
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        writes.push([key, value]);
+        data.set(key, value);
+      },
+      removeItem: (key: string) => data.delete(key),
+    },
+  });
+  return data;
+};
+
+const initialState = useGanttStore.getState();
+
+beforeEach(() => {
+  useGanttStore.setState({
+    ...initialState,
+    rawTasks: [],
+    transformedTasks: [],
+    bottomRowCells: [],
+    selectedScale: 'month',
+    currentTask: null,
+    dragOffsets: {},
+  });
+});
+
+describe('readPersistedScale', () => {
+  it('returns null when nothing is stored', () => {
+    stubSessionStorage();
+    expect(readPersistedScale()).toBeNull();
+  });
+
+  it('returns the stored scale', () => {
+    stubSessionStorage().set('gantt-scale', 'week');
+    expect(readPersistedScale()).toBe('week');
+  });
+
+  it('ignores an unknown stored value', () => {
+    stubSessionStorage().set('gantt-scale', 'fortnight');
+    expect(readPersistedScale()).toBeNull();
+  });
+
+  it('returns null instead of throwing when sessionStorage is unavailable', () => {
+    Reflect.deleteProperty(globalThis, 'sessionStorage');
+    expect(readPersistedScale()).toBeNull();
+  });
+});
+
+describe('setSelectedScale persistence', () => {
+  it('writes the scale once and skips a redundant write', () => {
+    stubSessionStorage();
+
+    useGanttStore.getState().setSelectedScale('week');
+    useGanttStore.getState().setSelectedScale('week');
+
+    expect(useGanttStore.getState().selectedScale).toBe('week');
+    expect(writes).toEqual([['gantt-scale', 'week']]);
+    expect(readPersistedScale()).toBe('week');
+  });
+
+  it('does not write on drag updates', () => {
+    stubSessionStorage();
+
+    for (let i = 0; i < 50; i++) {
+      useGanttStore.getState().setDragOffset('t1', {
+        offsetX: i,
+        offsetWidth: 0,
+        offsetStartDate: dayjs('2025-01-01'),
+        offsetEndDate: dayjs('2025-01-02'),
+      });
+    }
+    useGanttStore.getState().clearAllDragOffsets();
+    useGanttStore.getState().setRawTasks([]);
+
+    expect(writes).toEqual([]);
+  });
+
+  it('survives an unavailable sessionStorage', () => {
+    Reflect.deleteProperty(globalThis, 'sessionStorage');
+
+    expect(() => useGanttStore.getState().setSelectedScale('day')).not.toThrow();
+    expect(useGanttStore.getState().selectedScale).toBe('day');
+  });
+});
+
+describe('setRawTasks', () => {
+  it('accepts an empty array so the chart can be cleared', () => {
+    useGanttStore.setState({
+      rawTasks: [
+        {
+          id: 'a',
+          name: 'a',
+          startDate: '2025-01-01',
+          endDate: '2025-01-02',
+          parentId: null,
+          sequence: '1',
+        },
+      ],
+    });
+
+    useGanttStore.getState().setRawTasks([]);
+
+    expect(useGanttStore.getState().rawTasks).toEqual([]);
+  });
+});

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,3 +1,4 @@
+import { GANTT_SCALE_CONFIG } from "constants/gantt";
 import {
   GanttBottomRowCell,
   GanttDragOffset,
@@ -5,7 +6,28 @@ import {
 } from "types/gantt";
 import { Task, TaskTransformed } from "types/task";
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+
+/** 스케일 선택을 세션에 보존하는 키 */
+const SCALE_STORAGE_KEY = "gantt-scale";
+
+/**
+ * 세션에 저장된 스케일을 읽는다 - 저장값이 없거나 세션 저장소에 접근할 수 없으면 null
+ *
+ * 모듈 로드 시점이 아니라 마운트 이후에만 호출해야 한다.
+ * (SSR에서 import만으로 sessionStorage를 건드리지 않게, 그리고 첫 렌더를
+ *  서버와 동일하게 유지해 하이드레이션 불일치를 만들지 않게)
+ */
+export function readPersistedScale(): GanttScaleKey | null {
+  try {
+    const stored = sessionStorage.getItem(SCALE_STORAGE_KEY);
+    return stored && stored in GANTT_SCALE_CONFIG
+      ? (stored as GanttScaleKey)
+      : null;
+  } catch {
+    // SSR/프라이빗 모드 등 세션 저장소를 쓸 수 없는 환경
+    return null;
+  }
+}
 
 interface GanttState {
   rawTasks: Task[];
@@ -30,61 +52,64 @@ interface GanttState {
   getTotalWidth: () => number;
 }
 
-export const useGanttStore = create<GanttState>()(
-  persist(
-    (set, get) => ({
-      rawTasks: [],
-      transformedTasks: [],
-      bottomRowCells: [],
-      selectedScale: "month",
-      currentTask: null,
-      dragOffsets: {},
+export const useGanttStore = create<GanttState>()((set, get) => ({
+  rawTasks: [],
+  transformedTasks: [],
+  bottomRowCells: [],
+  selectedScale: "month",
+  currentTask: null,
+  dragOffsets: {},
 
-      setCurrentTask: (task) => set({ currentTask: task }),
-      setSelectedScale: (scale) => set({ selectedScale: scale }),
-      setRawTasks: (raw) => set({ rawTasks: raw }),
-      setBottomRowCells: (cells) => set({ bottomRowCells: cells }),
-      setTransformedTasks: (tasks) => set({ transformedTasks: tasks }),
+  setCurrentTask: (task) => set({ currentTask: task }),
 
-      setDragOffset: (id, offset) =>
-        set((state) => ({
-          dragOffsets: { ...state.dragOffsets, [id]: offset },
-        })),
-
-      clearDragOffset: (id) =>
-        set((state) => {
-          const { [id]: _removed, ...rest } = state.dragOffsets;
-          return { dragOffsets: rest };
-        }),
-
-      // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
-      // 타임라인 재계산에 휩쓸려 사라지지 않도록
-      clearAllDragOffsets: () =>
-        set((state) => {
-          const activeId = state.currentTask?.id;
-          const keys = Object.keys(state.dragOffsets);
-          if (!keys.length) return state;
-          if (!activeId || !state.dragOffsets[activeId]) {
-            return { dragOffsets: {} };
-          }
-          if (keys.length === 1) return state;
-          return { dragOffsets: { [activeId]: state.dragOffsets[activeId] } };
-        }),
-
-      getCurrentDragOffset: (taskId: string) => {
-        const state = get();
-        return state.dragOffsets[taskId] || null;
-      },
-
-      getTotalWidth: () => {
-        const state = get();
-        return state.bottomRowCells.reduce((sum, cell) => sum + cell.widthPx, 0);
-      },
-    }),
-    {
-      name: "gantt-storage",
-      storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => ({ selectedScale: state.selectedScale }),
+  // 세션 저장은 여기서만 - persist 미들웨어를 쓰면 드래그 프레임마다 스토어가
+  // 갱신될 때도 sessionStorage에 동기 쓰기가 발생한다
+  setSelectedScale: (scale) => {
+    if (get().selectedScale === scale) return;
+    set({ selectedScale: scale });
+    try {
+      sessionStorage.setItem(SCALE_STORAGE_KEY, scale);
+    } catch {
+      // 세션 저장소를 쓸 수 없는 환경 - 저장만 건너뛴다
     }
-  )
-);
+  },
+
+  setRawTasks: (raw) => set({ rawTasks: raw }),
+  setBottomRowCells: (cells) => set({ bottomRowCells: cells }),
+  setTransformedTasks: (tasks) => set({ transformedTasks: tasks }),
+
+  setDragOffset: (id, offset) =>
+    set((state) => ({
+      dragOffsets: { ...state.dragOffsets, [id]: offset },
+    })),
+
+  clearDragOffset: (id) =>
+    set((state) => {
+      const { [id]: _removed, ...rest } = state.dragOffsets;
+      return { dragOffsets: rest };
+    }),
+
+  // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
+  // 타임라인 재계산에 휩쓸려 사라지지 않도록
+  clearAllDragOffsets: () =>
+    set((state) => {
+      const activeId = state.currentTask?.id;
+      const keys = Object.keys(state.dragOffsets);
+      if (!keys.length) return state;
+      if (!activeId || !state.dragOffsets[activeId]) {
+        return { dragOffsets: {} };
+      }
+      if (keys.length === 1) return state;
+      return { dragOffsets: { [activeId]: state.dragOffsets[activeId] } };
+    }),
+
+  getCurrentDragOffset: (taskId: string) => {
+    const state = get();
+    return state.dragOffsets[taskId] || null;
+  },
+
+  getTotalWidth: () => {
+    const state = get();
+    return state.bottomRowCells.reduce((sum, cell) => sum + cell.widthPx, 0);
+  },
+}));


### PR DESCRIPTION
Builds on `fix/drag-correctness/64`.

## tasks prop sync (#68, #23)

The sync effect used to fire on every new `tasks` array identity, which is what a parent produces on almost any re-render (inline literal, non-memoised `map`). That overwrote whatever the user had just dragged, even though the edit had already been reported through `onTasksChange`.

The chart now compares the prop's *content* against the last content it ingested from the prop, not against the store:

- Parent re-renders with the same task data in a new array: ignored, so in-flight edits survive.
- Parent passes genuinely different data: the prop wins and replaces the store, including when the parent applies the edit it received from `onTasksChange`.
- `tasks={[]}`: that is a real change, so the chart clears — the old `tasks.length > 0` guard is gone. The timeline effect no longer bails out on an empty task list either, so the cells and rows are cleared instead of leaving stale bars behind.

In short the prop drives the chart, but only when it actually changes; a parent that echoes its own state back does not clobber state the chart owns. The comparison is a single `JSON.stringify` that runs only when the array identity changes, and the default `[]` is now a module constant so a caller that passes nothing never triggers it.

## defaultScale vs. the persisted scale (#24)

`defaultScale` was applied in a mount-only effect that always won, so it stomped the `sessionStorage`-persisted scale on every remount. It is now a seed: on mount the chart reads the persisted scale and falls back to `defaultScale` only when nothing is stored. Changing the prop after mount is still ignored, which is the usual `default*` contract, and both facts are documented in the prop's JSDoc.

## sessionStorage writes (#82)

The zustand `persist` middleware wrote synchronously on every store update, drag frames included, even though `partialize` only kept `selectedScale`. The middleware is gone; `setSelectedScale` writes the one key itself and returns early when the scale has not changed, so nothing else in the store can trigger a write.

## theme="system" hydration (#86)

The resolved theme was read from `window.matchMedia` during the first render, which does not match what the server rendered. It now comes from `useSyncExternalStore` with a server snapshot of `null`: the server and the hydration render emit no theme class at all, and the real system theme is applied after hydration. Client-only renders still resolve on the first paint, so there is no flash there either. Explicit `theme="light" | "dark"` is unchanged, and passing no `theme` still leaves theming entirely to the host.

## SSR safety (#29)

Nothing touches `window`, `document` or `sessionStorage` at module scope any more — the persisted store and the theme listener were the two risks. CI gains a smoke test after the build that imports the built package in plain Node (ESM and CJS) and server-renders it with `react-dom/server`, so a future module-scope browser global fails the build instead of the host app.

Local output:

```
SSR import OK (esm)
SSR import OK (cjs)
SSR render OK
```

## ScaleSelector roving tabindex (#76)

Arrow keys changed the selection but never moved focus, so the next press recomputed from the same button and repeated presses were no-ops. The base index now comes from the selected scale, and the newly selected button is focused, so focus follows the selection and only the active option is tabbable.

## Verification

`pnpm lint` (0 errors, the 4 pre-existing warnings), `pnpm type-check`, `pnpm test` (21 passed), `pnpm build` all pass. New store tests cover the persisted-scale read, the single write per scale change, no writes during drag updates, and the empty-task path.

Browser-checked on a dev server with a host harness: a bar drag commits and fires `onTasksChange`; a parent re-render echoing the old data leaves the dragged bar in place; a real prop change wins; `tasks={[]}` renders an empty chart with no console errors and repopulates on restore; arrow keys move both selection and focus through the scale buttons and persist the choice across a reload.

Closes #68
Closes #23
Closes #24
Closes #82
Closes #86
Closes #29
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
