### PR TITLE
fix: DST-safe date math and a UTC timeline policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ type DependencyType = 'FS' | 'SS' | 'FF' | 'SF';
 // SF = Start-to-Finish
 ```
 
+### Time zone
+
+**The chart draws and labels the timeline in UTC.** The grid, the bars, the tick and header
+labels, and the drag tooltips all use UTC, so the same tasks render identically for every
+viewer — a chart shared between Seoul and London puts every bar on the same day cell.
+`onTasksChange` hands back UTC ISO strings (`2024-06-01T09:00:00.000Z`).
+
+- A string with a zone (`"2024-06-01T09:00:00Z"`, `"2024-06-01T18:00:00+09:00"`) is that
+  instant, shown at its UTC clock time — both examples render at `09:00`.
+- A string without a zone (`"2024-06-01"`, `"2024-06-01T09:00"`) is read as UTC wall clock,
+  so it renders exactly as written and lands on the day it names, wherever the viewer is.
+
+`holidays` entries are UTC days too, and the `Dayjs` handed to `isNonWorkingDay` is in UTC mode,
+so `date.day()` inside it is the UTC weekday.
+
+Want the chart to read in your own zone instead? Convert to that zone's wall clock and drop
+the offset before passing the tasks in (e.g. `"2024-06-01T18:00"` for 18:00 KST), and convert
+back in `onTasksChange`. There is no per-viewer local-time mode: local rendering would move
+bars between day cells depending on where the viewer sits, and local DST days (23 or 25 hours
+long) would make a one-day drag land an hour off the day it was dropped on.
+
 ## Timeline Scales
 
 | Scale | Header Label | Tick Unit | Drag Step |

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -15,9 +15,12 @@ export const MILESTONE_SIZE = 16;
 /** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
 export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
-/** 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제 */
+/**
+ * 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제
+ * 차트는 UTC로 그리므로 시각이 보이는 day 스케일에만 존을 표기한다
+ */
 export const DATE_FORMATS: Record<GanttScaleKey, string> = {
-  day: 'MMM D, YYYY HH:mm',
+  day: 'MMM D, YYYY HH:mm [UTC]',
   week: 'MMM D, YYYY',
   month: 'MMM D, YYYY',
   year: 'MMM YYYY',

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -3,11 +3,13 @@ import {
   GANTT_SCALE_CONFIG,
   MIN_RESIZABLE_WIDTH,
 } from "constants/gantt";
+import { Dayjs } from "dayjs";
 import { useRef } from "react";
 import { useGanttStore, useGanttStoreApi } from "stores/context";
-import { GanttDragOffset } from "types/gantt";
+import { GanttDragOffset, GanttScaleKey } from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
+import { shiftByDragSteps } from "utils/timeline";
 
 export type DragMode = "bar" | "left" | "right";
 
@@ -15,24 +17,15 @@ interface DragContext {
   mode: DragMode;
   pointerId: number;
   initialClientX: number;
-  initialStartDate: dayjs.Dayjs;
-  initialEndDate: dayjs.Dayjs;
+  initialStartDate: Dayjs;
+  initialEndDate: Dayjs;
   initialBarWidth: number;
   dragSteps: number;
   basePxPerDragStep: number;
-  dragStepAmount: number;
-  dragStepUnit: string;
+  // 드래그 도중 스케일이 바뀌어도 시작 시점의 스텝 단위로 계산한다
+  scaleKey: GanttScaleKey;
   taskId: string;
 }
-
-// 시간 단위 변환 상수
-const TIME_UNIT_MULTIPLIERS = {
-  minute: 1,
-  hour: 60,
-  day: 60 * 24,
-  week: 60 * 24 * 7,
-  month: 60 * 24 * 30,
-} as const;
 
 /**
  * Gantt 바 드래그 기능을 제공하는 훅
@@ -48,8 +41,7 @@ export function useGanttBarDrag(
   onTasksChangeRef.current = onTasksChange;
 
   const selectedScale = useGanttStore((s) => s.selectedScale);
-  const scaleConfig = GANTT_SCALE_CONFIG[selectedScale];
-  const { basePxPerDragStep, dragStepAmount, dragStepUnit } = scaleConfig;
+  const { basePxPerDragStep } = GANTT_SCALE_CONFIG[selectedScale];
 
   // 드래그 모드 감지
   // 마일스톤과 좁은 바는 리사이즈 불가 - 엣지 영역이 바 전체를 덮어 이동이 막히는 것을 방지
@@ -84,8 +76,7 @@ export function useGanttBarDrag(
       initialBarWidth: task.barWidth,
       dragSteps: 0,
       basePxPerDragStep,
-      dragStepAmount,
-      dragStepUnit,
+      scaleKey: selectedScale,
       taskId: task.id,
     };
 
@@ -112,24 +103,23 @@ export function useGanttBarDrag(
       ctx.dragSteps = steps;
 
       const draggedPx = steps * ctx.basePxPerDragStep;
-      const minutesPerStep = ctx.dragStepAmount * TIME_UNIT_MULTIPLIERS[ctx.dragStepUnit as keyof typeof TIME_UNIT_MULTIPLIERS];
-      const totalMinutes = steps * minutesPerStep;
+      const shift = (date: Dayjs) => shiftByDragSteps(date, steps, ctx.scaleKey);
 
-      let newStartDate: dayjs.Dayjs;
-      let newEndDate: dayjs.Dayjs;
+      let newStartDate: Dayjs;
+      let newEndDate: Dayjs;
       let offsetX = 0;
       let offsetWidth = 0;
 
       switch (ctx.mode) {
         case "bar":
-          newStartDate = ctx.initialStartDate.add(totalMinutes, "minute");
-          newEndDate = ctx.initialEndDate.add(totalMinutes, "minute");
+          newStartDate = shift(ctx.initialStartDate);
+          newEndDate = shift(ctx.initialEndDate);
           offsetX = draggedPx;
           offsetWidth = 0;
           break;
 
         case "left":
-          newStartDate = ctx.initialStartDate.add(totalMinutes, "minute");
+          newStartDate = shift(ctx.initialStartDate);
           newEndDate = ctx.initialEndDate;
           offsetX = draggedPx;
           offsetWidth = -draggedPx;
@@ -137,7 +127,7 @@ export function useGanttBarDrag(
 
         case "right":
           newStartDate = ctx.initialStartDate;
-          newEndDate = ctx.initialEndDate.add(totalMinutes, "minute");
+          newEndDate = shift(ctx.initialEndDate);
           offsetX = 0;
           offsetWidth = draggedPx;
           break;
@@ -195,8 +185,8 @@ export function useGanttBarDrag(
       }
 
       const currentRawTasks = storeApi.getState().rawTasks;
-      const minutesPerStep = ctx.dragStepAmount * TIME_UNIT_MULTIPLIERS[ctx.dragStepUnit as keyof typeof TIME_UNIT_MULTIPLIERS];
-      const totalMinutes = ctx.dragSteps * minutesPerStep;
+      const commit = (date: string) =>
+        shiftByDragSteps(dayjs(date), ctx.dragSteps, ctx.scaleKey).toISOString();
 
       const updatedTasks = currentRawTasks.map((t) => {
         if (t.id !== ctx.taskId) return t;
@@ -205,20 +195,20 @@ export function useGanttBarDrag(
           case "bar":
             return {
               ...t,
-              startDate: dayjs(t.startDate).add(totalMinutes, "minute").toISOString(),
-              endDate: dayjs(t.endDate).add(totalMinutes, "minute").toISOString(),
+              startDate: commit(t.startDate),
+              endDate: commit(t.endDate),
             };
 
           case "left":
             return {
               ...t,
-              startDate: dayjs(t.startDate).add(totalMinutes, "minute").toISOString(),
+              startDate: commit(t.startDate),
             };
 
           case "right":
             return {
               ...t,
-              endDate: dayjs(t.endDate).add(totalMinutes, "minute").toISOString(),
+              endDate: commit(t.endDate),
             };
 
           default:

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,6 +1,21 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 
 // 플러그인은 실제로 쓰는 것만 등록한다.
 // (이전에는 12개를 등록했지만 호출부가 하나도 없어 번들만 키웠다)
+dayjs.extend(utc);
 
-export default dayjs;
+/**
+ * 차트 전용 dayjs - 항상 UTC 모드로 파싱하고 표시한다.
+ *
+ * 태스크 날짜의 계약이 "UTC ISO 문자열"이므로(README > Task Format) 배치와 라벨도
+ * UTC에 맞춘다. 로컬 모드로 파싱하면 같은 데이터가 뷰어의 위치에 따라 다른 날짜
+ * 칸에 그려지고(#84), 로컬 달력의 DST 날(23/25시간) 때문에 셀 너비도 흔들린다(#28).
+ *
+ * - 존이 붙은 문자열('...Z', '+09:00')은 그 순간을 UTC 시각으로 표시한다
+ * - 존이 없는 문자열('2025-06-01', '2025-06-01T09:00')은 UTC 벽시계로 읽으므로
+ *   뷰어 타임존과 무관하게 적은 그대로 표시된다
+ */
+const ganttDayjs = dayjs.utc;
+
+export default ganttDayjs;

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -51,6 +51,22 @@ export function computeNonWorkingRanges(
   return ranges;
 }
 
+/**
+ * 드래그 스텝 수만큼 날짜를 옮긴다
+ *
+ * 스케일의 드래그 단위(hour/day)를 그대로 더한다. 분으로 환산해서 더하면
+ * (day = 1440분) 로컬 달력의 DST 경계에서 하루가 23/25시간이라 한 시간씩
+ * 어긋나고, 자정 근처 태스크는 아예 다른 날짜 칸에 커밋된다.
+ */
+export function shiftByDragSteps(
+  date: Dayjs,
+  steps: number,
+  scaleKey: GanttScaleKey
+): Dayjs {
+  const { dragStepUnit, dragStepAmount } = GANTT_SCALE_CONFIG[scaleKey];
+  return date.add(steps * dragStepAmount, dragStepUnit);
+}
+
 export function calculateDateOffsets(
   startDate: Dayjs,
   endDate: Dayjs,

--- a/src/utils/timezone.test.ts
+++ b/src/utils/timezone.test.ts
@@ -1,0 +1,172 @@
+import localDayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import { GANTT_SCALE_CONFIG } from 'constants/gantt';
+import type { Task } from 'types/task';
+import dayjs from 'utils/dayjs';
+import { computeTimelineData, shiftByDragSteps } from './timeline';
+
+/**
+ * 테스트 동안만 뷰어의 로컬 타임존을 바꾼다.
+ * (Node는 process.env.TZ 대입 즉시 Date 계산에 반영한다)
+ */
+function withTimeZone<T>(tz: string, fn: () => T): T {
+  const prev = process.env.TZ;
+  process.env.TZ = tz;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.TZ;
+    else process.env.TZ = prev;
+  }
+}
+
+const task = (startDate: string, endDate: string): Task => ({
+  id: 'a',
+  name: 'a',
+  startDate,
+  endDate,
+  parentId: null,
+  sequence: '1',
+});
+
+const widths = (t: Task, scale: 'day' | 'week' | 'month' | 'year') =>
+  computeTimelineData([t], scale).bottomCells.map((c) => c.widthPx);
+
+// America/New_York: 2025-03-09 는 23시간(봄 DST), 2025-11-02 는 25시간(가을 DST)
+const SPRING_FORWARD = task('2025-03-08T00:00:00Z', '2025-03-10T00:00:00Z');
+const FALL_BACK = task('2025-11-01T00:00:00Z', '2025-11-03T00:00:00Z');
+
+describe('DST 경계에서의 타임라인 셀 (#28)', () => {
+  it('봄 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
+    // 예전: 23시간짜리 하루가 diff('day') 정수 절삭으로 0일이 되어 3/9 셀이 0px로 사라졌다
+    withTimeZone('America/New_York', () => {
+      expect(new Set(widths(SPRING_FORWARD, 'month'))).toEqual(new Set([32]));
+      expect(new Set(widths(SPRING_FORWARD, 'week'))).toEqual(new Set([216]));
+    });
+  });
+
+  it('가을 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
+    // 예전: 25시간짜리 하루가 week 스케일에서 225px(다른 날은 216px)로 튀었다
+    withTimeZone('America/New_York', () => {
+      expect(new Set(widths(FALL_BACK, 'month'))).toEqual(new Set([32]));
+      expect(new Set(widths(FALL_BACK, 'week'))).toEqual(new Set([216]));
+    });
+  });
+
+  it('year 스케일 월 셀 너비가 실제 달력 월 길이를 따른다', () => {
+    // year: dragStepUnit 'day' 7일, basePxPerDragStep 28 -> 하루 4px
+    // 예전: DST가 낀 3월이 30.96일로 잘려 124px 대신 120px이 되었다
+    withTimeZone('America/New_York', () => {
+      const cells = computeTimelineData(
+        [task('2025-02-01T00:00:00Z', '2025-07-01T00:00:00Z')],
+        'year',
+      ).bottomCells;
+      const byMonth = new Map(
+        cells.map((c) => [c.startDate.format('YYYY-MM'), c.widthPx]),
+      );
+      expect(byMonth.get('2025-02')).toBe(28 * 4);
+      expect(byMonth.get('2025-03')).toBe(31 * 4); // DST 있음
+      expect(byMonth.get('2025-04')).toBe(30 * 4);
+      expect(byMonth.get('2025-11')).toBe(30 * 4); // DST 있음
+    });
+  });
+});
+
+describe('shiftByDragSteps (#28)', () => {
+  it('달력 단위로 더해 봄 DST를 가로질러도 시각이 유지된다', () => {
+    // 로컬 모드 인스턴스로도 검증 - 분으로 환산해 더하던 예전 방식은
+    // 3/8 23:30 EST + 1440분 = 3/10 00:30 EDT 로 하루가 아니라 이틀 뒤 칸에 떨어졌다
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-03-08T23:30');
+      expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-09 23:30',
+      );
+      expect(shiftByDragSteps(start, 2, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-10 23:30',
+      );
+      expect(shiftByDragSteps(start, -1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-07 23:30',
+      );
+    });
+  });
+
+  it('달력 단위로 더해 가을 DST를 가로질러도 시각이 유지된다', () => {
+    // 예전: 11/1 23:30 EDT + 1440분 = 11/2 22:30 EST (하루가 25시간이라 한 시간 모자람)
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-11-01T23:30');
+      expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-11-02 23:30',
+      );
+    });
+  });
+
+  it('year 스케일 7일 스텝도 DST를 가로질러 정확히 7일씩 움직인다', () => {
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-03-05T09:00');
+      expect(shiftByDragSteps(start, 1, 'year').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-12 09:00',
+      );
+    });
+  });
+
+  it('스케일별 드래그 스텝이 config 그대로다', () => {
+    const base = dayjs('2025-01-01T00:00:00Z');
+    expect(shiftByDragSteps(base, 3, 'day').toISOString()).toBe('2025-01-01T03:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'week').toISOString()).toBe('2025-01-01T18:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'month').toISOString()).toBe('2025-01-04T00:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'year').toISOString()).toBe('2025-01-22T00:00:00.000Z');
+    // month 스케일 스텝을 30일 고정으로 환산하면 실제 달 길이와 어긋난다
+    expect(shiftByDragSteps(dayjs('2025-01-31T00:00:00Z'), 30, 'month').toISOString()).toBe(
+      '2025-03-02T00:00:00.000Z',
+    );
+  });
+});
+
+describe('UTC 기준 배치 (#84)', () => {
+  const boundary = task('2025-03-10T23:00:00Z', '2025-03-11T05:00:00Z');
+
+  it('뷰어 타임존이 달라도 같은 데이터가 같은 위치에 그려진다', () => {
+    const seoul = withTimeZone('Asia/Seoul', () => computeTimelineData([boundary], 'month'));
+    const london = withTimeZone('Europe/London', () =>
+      computeTimelineData([boundary], 'month'),
+    );
+
+    expect(seoul.transformedTasks[0].barLeft).toBe(london.transformedTasks[0].barLeft);
+    expect(seoul.transformedTasks[0].barWidth).toBe(london.transformedTasks[0].barWidth);
+    expect(seoul.bottomCells.map((c) => c.startDate.toISOString())).toEqual(
+      london.bottomCells.map((c) => c.startDate.toISOString()),
+    );
+  });
+
+  it('UTC 날짜 경계 태스크가 UTC 달력 칸에 붙는다', () => {
+    // 3/10 23:00Z 시작 -> "Mar 10" 칸의 23/24 지점
+    const { bottomCells, transformedTasks } = withTimeZone('Asia/Seoul', () =>
+      computeTimelineData([boundary], 'month'),
+    );
+    const index = bottomCells.findIndex(
+      (c) => c.startDate.format('YYYY-MM-DD') === '2025-03-10',
+    );
+
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(transformedTasks[0].barLeft).toBeCloseTo(index * 32 + (32 * 23) / 24, 5);
+    expect(transformedTasks[0].barWidth).toBeCloseTo((32 * 6) / 24, 5);
+  });
+
+  it('셀 라벨과 헤더가 UTC 달력 날짜를 쓴다', () => {
+    const { bottomCells } = withTimeZone('Asia/Seoul', () =>
+      computeTimelineData([task('2025-06-01T00:00:00Z', '2025-06-02T00:00:00Z')], 'month'),
+    );
+    const labels = bottomCells.map((c) => GANTT_SCALE_CONFIG.month.formatTickLabel?.(c.startDate));
+
+    // 첫 셀은 6/1에서 5틱 앞선 5/27
+    expect(bottomCells[0].startDate.toISOString()).toBe('2025-05-27T00:00:00.000Z');
+    expect(labels.slice(0, 6)).toEqual(['27', '28', '29', '30', '31', '1']);
+  });
+
+  it('존 없는 문자열은 UTC 벽시계로 읽어 적은 그대로 표시한다', () => {
+    withTimeZone('Asia/Seoul', () => {
+      expect(dayjs('2025-06-01T09:00').format('YYYY-MM-DD HH:mm')).toBe('2025-06-01 09:00');
+      expect(dayjs('2025-06-01').toISOString()).toBe('2025-06-01T00:00:00.000Z');
+    });
+  });
+});

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -166,7 +166,7 @@ describe('GANTT_SCALE_CONFIG labels', () => {
     expect(GANTT_SCALE_CONFIG.week.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
     expect(GANTT_SCALE_CONFIG.month.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
     expect(GANTT_SCALE_CONFIG.year.formatHeaderLabel?.(afternoon)).toBe('2025');
-    expect(afternoon.format(DATE_FORMATS.day)).toBe('Sep 1, 2025 15:00');
+    expect(afternoon.format(DATE_FORMATS.day)).toBe('Sep 1, 2025 15:00 UTC');
     expect(afternoon.format(DATE_FORMATS.week)).toBe('Sep 1, 2025');
   });
 });


### PR DESCRIPTION
Two date-correctness bugs, one root cause each.

## 1. DST-unsafe drag arithmetic (#28)

`useGanttBarDrag` turned a drag into **minutes** through a lookup table
(`day: 60*24`, `week: 60*24*7`, `month: 60*24*30`) and then did
`.add(totalMinutes, "minute")`. A calendar day is not always 1440 minutes, so a
"one day" drag over a DST boundary landed an hour off — and a task near midnight
landed on the **wrong calendar day**.

Before / after, `America/New_York`, month scale, drag one step right:

| | start | + 1 day step |
|---|---|---|
| before | `2025-03-08 23:30` | `2025-03-10 00:30` ❌ two days later |
| after | `2025-03-08 23:30` | `2025-03-09 23:30` ✅ |

Fall-back has the mirror bug (`2025-11-01 23:30` + 1 day → `2025-11-02 22:30`),
and the `month: 30 days` entry was dead code that matched no month of the year.

Fix: `shiftByDragSteps()` adds the scale's own calendar unit
(`.add(steps * dragStepAmount, dragStepUnit)`). The multiplier table is gone, and
the preview and the commit path now share one function instead of duplicating the
math.

Cell sizing had the same class of bug: at week scale a DST day rendered 207px or
225px against 216px for every other day, because `diff` in the drag-step unit
measures real elapsed hours.

## 2. UTC input rendered in the viewer's local zone (#84)

The README already contracts task dates as **UTC ISO strings**, but parsing was
plain local-mode `dayjs()`. So the same data drew differently per viewer: a task
`2025-03-10T23:00Z–2025-03-11T05:00Z` sat under "Mar 11" in Seoul and spanned
"Mar 10–11" in London, and the demo's `09:00–17:00Z` tasks showed as `18:00–02:00(+1d)`
in KST, occupying an extra day cell.

**Policy chosen: the chart draws and labels the timeline in UTC.** `utils/dayjs`
is now pinned to UTC mode, which is the whole implementation — grid, bars, tick
and header labels, drag tooltips and `onTasksChange` round-trips all agree, and
the same tasks render identically for every viewer.

Why this over a `timeZone` prop defaulting to local:

- It makes the documented input contract true instead of half-true.
- Per-viewer local rendering is the bug: for a scheduling chart the day a bar sits
  under is the product, and it must not depend on where the reader is.
- UTC has no DST, so the grid has no 23/25-hour days at all — the drag fix above
  is then belt *and* braces rather than the only thing standing between a user and
  a misplaced bar.
- Zone-less input still works the intuitive way: `"2025-06-01T09:00"` is read as
  UTC wall clock and renders as `09:00`, so a team that wants its own zone passes
  local wall-clock strings and gets exactly what it wrote.

Documented under **Task Format → Time zone** in the README, including the
`isNonWorkingDay`/`holidays` consequence (both are UTC days now). The day-scale
tooltip says `[UTC]` explicitly so a time-of-day label is never ambiguous.

## Tests

11 new regression tests in `src/utils/timezone.test.ts`, all of which fail against
the current code (verified by running them against it):

- spring-forward and fall-back cell widths at month and week scale, `America/New_York`
- calendar-month lengths at year scale (Feb 112px, Mar 124px, Apr/Nov 120px)
- `shiftByDragSteps` across both DST directions, including a local-mode instance so
  the arithmetic is proven DST-safe on its own, not just because UTC hides DST
- identical layout for the same tasks in `Asia/Seoul` and `Europe/London`
- UTC day-boundary tasks landing in the UTC day cell, and zone-less parsing

The existing suite deliberately uses bare dates to stay timezone-independent and
still passes; the whole suite passes under `TZ` = `America/New_York`, `Asia/Seoul`,
`UTC` and `Australia/Lord_Howe` (30-minute DST).

`pnpm lint` (0 errors, 4 pre-existing warnings), `pnpm type-check`, `pnpm test`
(45 passed) and `pnpm build` all pass.

## Browser verification

Chromium with `timezoneId: America/New_York`, real mouse drags:

- month scale, bar under tick `6` dragged +3 steps across spring-forward 2026-03-08
  → committed `2026-03-09T09:00:00.000Z` / `2026-03-10T17:00:00.000Z`, bar now under
  tick `9` of `Mar 2026`
- month scale, tick `30` dragged −2 steps near fall-back 2026-11-01
  → `2026-10-28T09:00:00.000Z`, bar under tick `28`
- day scale, +3 steps → tooltip reads `Mar 6, 2026 12:00 UTC → Mar 7, 2026 20:00 UTC`,
  matching the committed ISO exactly
- `Mar 2026` header group measures 992px = 31 × 32px (no short DST month)

Closes #28
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)