### PR TITLE
perf: map-based dependency lookup, arrow culling, header cell virtualization

### DIFF
--- a/src/components/GanttChartHeader.tsx
+++ b/src/components/GanttChartHeader.tsx
@@ -1,4 +1,5 @@
 import { GANTT_SCALE_CONFIG } from "constants/gantt";
+import { useGanttColumnVirtualization } from "hooks/useGanttVirtualization";
 import React, { useMemo } from "react";
 import { GanttBottomRowCell, GanttScaleKey } from "types/gantt";
 import { mergeHeaderGroups } from "utils/headerUtils";
@@ -8,8 +9,8 @@ interface GanttChartHeaderProps {
   bottomRowCells: GanttBottomRowCell[];
   selectedScale: GanttScaleKey;
   width: number;
-  /** 사용하지 않음 - 상단 그룹 라벨 고정은 CSS sticky로 처리 */
-  scrollRef?: React.RefObject<HTMLDivElement | null>;
+  /** 하단 시간 셀 가상화용 스크롤 컨테이너 (상단 그룹 라벨 고정은 CSS sticky로 처리) */
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -20,8 +21,18 @@ function GanttChartHeader({
   bottomRowCells,
   selectedScale,
   width,
+  scrollRef,
 }: GanttChartHeaderProps) {
   const config = GANTT_SCALE_CONFIG[selectedScale];
+
+  // 하단 셀은 열 가상화 - day 스케일의 긴 범위는 셀이 수천 개다
+  // (상단 그룹은 병합된 소수의 라벨이라 그대로 그린다)
+  const { columnVirtualizer } = useGanttColumnVirtualization({
+    bottomRowCells,
+    scrollRef,
+  });
+  const virtualCells = columnVirtualizer.getVirtualItems();
+  const leadingPx = virtualCells[0]?.start ?? 0;
 
   // 헤더 그룹 생성 및 병합 (memoized)
   const topGroups = useMemo(
@@ -48,16 +59,21 @@ function GanttChartHeader({
           </div>
         </div>
 
-        {/* 하단 시간 셀 */}
+        {/* 하단 시간 셀 (가시 영역만) */}
         <div className="gantt-bottom-row">
-          {bottomRowCells.map((cell, idx) => {
+          {/* 건너뛴 앞쪽 셀들의 폭 - flex 흐름을 그대로 두려고 스페이서로 민다 */}
+          <div style={{ width: `${leadingPx}px` }} aria-hidden="true" />
+          {virtualCells.map((virtualCell) => {
+            const cell = bottomRowCells[virtualCell.index];
+            if (!cell) return null;
+
             const tickLabel = config.formatTickLabel?.(cell.startDate) || "";
 
             return (
               <div
-                key={`bottom-${idx}`}
+                key={`bottom-${virtualCell.index}`}
                 className="gantt-bottom-cell"
-                style={{ width: `${cell.widthPx}px` }}
+                style={{ width: `${virtualCell.size}px` }}
               >
                 {tickLabel}
               </div>

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -1,8 +1,15 @@
 import { NODE_HEIGHT } from "constants/gantt";
-import { useId } from "react";
+import { useGanttVirtualization } from "hooks/useGanttVirtualization";
+import { useCallback, useId, useMemo, useRef } from "react";
 import { useGanttStore } from "stores/context";
 import { TaskTransformed } from "types/task";
-import { buildDependencies, getSmartGanttPath } from "utils/arrowPath";
+import {
+  ArrowViewport,
+  buildDependencies,
+  buildTaskIndex,
+  getSmartGanttPath,
+  isArrowVisible,
+} from "utils/arrowPath";
 
 interface Props {
   transformedTasks: TaskTransformed[];
@@ -12,7 +19,41 @@ export default function GanttDependencyArrows({
   transformedTasks,
 }: Props) {
   const liveOffsets = useGanttStore((store) => store.dragOffsets);
-  const dependencies = buildDependencies(transformedTasks, liveOffsets);
+  const bottomRowCells = useGanttStore((store) => store.bottomRowCells);
+
+  // 스크롤 컨테이너는 SVG의 조상이라 마운트 시 직접 찾는다.
+  // 바 컬링과 같은 가상화 창을 써야 화살표만 먼저 잘리는 일이 없다.
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const attachSvg = useCallback((svg: SVGSVGElement | null) => {
+    scrollRef.current =
+      svg?.closest<HTMLDivElement>(".gantt-scroll-container") ?? null;
+  }, []);
+
+  const { rowVirtualizer, isBarVisible } = useGanttVirtualization({
+    transformedTasks,
+    bottomRowCells,
+    scrollRef,
+  });
+
+  // 태스크 인덱스는 데이터가 바뀔 때만 다시 만든다 (드래그 프레임마다가 아니라)
+  const taskById = useMemo(
+    () => buildTaskIndex(transformedTasks),
+    [transformedTasks]
+  );
+
+  // 화면 밖 화살표는 만들지 않는다 - 행은 이미 가상화되어 있어서
+  // 대량 데이터에서는 화살표가 실질적인 한계였다
+  const visibleRows = rowVirtualizer.getVirtualItems();
+  const lastRow = visibleRows[visibleRows.length - 1];
+  const viewport: ArrowViewport = {
+    topPx: visibleRows[0]?.start ?? 0,
+    bottomPx: lastRow ? lastRow.start + lastRow.size : 0,
+    isBarVisible,
+  };
+
+  const dependencies = buildDependencies(taskById, liveOffsets).filter((dep) =>
+    isArrowVisible(dep, viewport)
+  );
 
   // marker id는 문서 전역이라 인스턴스마다 고유해야 차트를 여러 개 띄워도 안 섞인다
   // useId 값에는 url(#...) 참조에 부적합한 문자가 섞이므로 영숫자만 남긴다
@@ -21,6 +62,7 @@ export default function GanttDependencyArrows({
 
   return (
     <svg
+      ref={attachSvg}
       className="gantt-dependency-arrows"
       style={{
         height: `${transformedTasks.length * NODE_HEIGHT}px`,

--- a/src/hooks/useGanttVirtualization.ts
+++ b/src/hooks/useGanttVirtualization.ts
@@ -4,36 +4,39 @@ import { RefObject, useEffect, useMemo } from "react";
 import { GanttBottomRowCell } from "types/gantt";
 import { TaskTransformed } from "types/task";
 
-interface UseGanttVirtualizationParams {
-  transformedTasks: TaskTransformed[];
+interface UseGanttColumnVirtualizationParams {
   bottomRowCells: GanttBottomRowCell[];
   scrollRef: RefObject<HTMLDivElement | null>;
 }
 
-interface UseGanttVirtualizationResult {
-  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+interface UseGanttColumnVirtualizationResult {
   columnVirtualizer: Virtualizer<HTMLDivElement, Element>;
   isBarVisible: (barLeft: number, barWidth: number) => boolean;
 }
 
+interface UseGanttVirtualizationParams
+  extends UseGanttColumnVirtualizationParams {
+  transformedTasks: TaskTransformed[];
+}
+
+interface UseGanttVirtualizationResult
+  extends UseGanttColumnVirtualizationResult {
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+}
+
 /**
- * Gantt 차트의 가상화 로직을 관리하는 훅
- * 행(row)과 열(column) 가상화를 설정하고 가시성 체크 함수 제공
+ * 열(column) 가상화
+ *
+ * 헤더의 하단 시간 셀 렌더와 가로 가시성 판정을 같은 창(window)으로 맞추기 위해
+ * 따로 떼어 두었다 - 헤더와 바가 서로 다른 기준으로 잘리면 안 된다.
  */
-export function useGanttVirtualization({
-  transformedTasks,
+export function useGanttColumnVirtualization({
   bottomRowCells,
   scrollRef,
-}: UseGanttVirtualizationParams): UseGanttVirtualizationResult {
-  // 행 가상화 설정
-  const rowVirtualizer = useVirtualizer({
-    count: transformedTasks.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => NODE_HEIGHT,
-    overscan: 5,
-  });
-
-  // 열 가상화 설정
+}: UseGanttColumnVirtualizationParams): UseGanttColumnVirtualizationResult {
+  // TanStack Virtual이 돌려주는 함수는 메모이즈할 수 없어 React Compiler가
+  // 이 훅을 건너뛴다 - 아래 행 가상화에 같은 경고가 이미 남아 있어 중복만 끈다
+  // eslint-disable-next-line react-hooks/incompatible-library
   const columnVirtualizer = useVirtualizer({
     horizontal: true,
     count: bottomRowCells.length,
@@ -70,8 +73,32 @@ export function useGanttVirtualization({
   }, [bottomRowCells, columnVirtualizer]);
 
   return {
-    rowVirtualizer,
     columnVirtualizer,
     isBarVisible,
+  };
+}
+
+/**
+ * Gantt 차트의 가상화 로직을 관리하는 훅
+ * 행(row)과 열(column) 가상화를 설정하고 가시성 체크 함수 제공
+ */
+export function useGanttVirtualization({
+  transformedTasks,
+  bottomRowCells,
+  scrollRef,
+}: UseGanttVirtualizationParams): UseGanttVirtualizationResult {
+  // 행 가상화 설정
+  const rowVirtualizer = useVirtualizer({
+    count: transformedTasks.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => NODE_HEIGHT,
+    overscan: 5,
+  });
+
+  const column = useGanttColumnVirtualization({ bottomRowCells, scrollRef });
+
+  return {
+    rowVirtualizer,
+    ...column,
   };
 }

--- a/src/utils/arrowPath.ts
+++ b/src/utils/arrowPath.ts
@@ -374,18 +374,64 @@ export function calculateArrowCoords(
   return { fromX, fromY, toX, toY };
 }
 
-/** 의존성 배열 빌드 */
+/**
+ * id로 태스크를 찾기 위한 인덱스.
+ *
+ * 태스크 배열이 바뀔 때 한 번만 만들어 재사용한다 - 의존성마다 배열을 훑으면
+ * 태스크 수의 제곱에 비례하는 비용이 드래그 프레임마다 다시 발생한다.
+ */
+export function buildTaskIndex(
+  transformedTasks: TaskTransformed[]
+): Map<string, TaskTransformed> {
+  return new Map(transformedTasks.map((task) => [task.id, task]));
+}
+
+/** 화살표 하나가 뷰포트를 벗어나는지 판정할 때 두는 여유 (px) */
+const ARROW_BLEED = 32;
+
+/** 화살표 컬링용 가시 영역 */
+export interface ArrowViewport {
+  /** 세로 가시 범위 (행 가상화 기준, px) */
+  topPx: number;
+  bottomPx: number;
+  /** 가로 가시성 - 열 가상화의 바 가시성 판정을 그대로 쓴다 */
+  isBarVisible: (left: number, width: number) => boolean;
+}
+
+/**
+ * 화살표가 가시 영역과 겹치는지 판정.
+ *
+ * 양 끝 좌표의 바운딩 박스로 보므로 양쪽 끝이 모두 화면 밖이어도 선이 화면을
+ * 가로지르면 그린다. 꺾인 경로가 끝점보다 조금 바깥으로 나가므로 여유를 둔다.
+ */
+export function isArrowVisible(
+  dep: Pick<RenderedDependency, "fromX" | "fromY" | "toX" | "toY">,
+  viewport: ArrowViewport
+): boolean {
+  const top = Math.min(dep.fromY, dep.toY) - ARROW_BLEED;
+  const bottom = Math.max(dep.fromY, dep.toY) + ARROW_BLEED;
+  if (bottom < viewport.topPx || top > viewport.bottomPx) return false;
+
+  const left = Math.min(dep.fromX, dep.toX) - ARROW_BLEED;
+  const right = Math.max(dep.fromX, dep.toX) + ARROW_BLEED;
+  return viewport.isBarVisible(left, right - left);
+}
+
+/**
+ * 의존성 배열 빌드.
+ * 인덱스를 순회 대상 겸 조회용으로 쓴다 (삽입 순서 = 태스크 순서).
+ */
 export function buildDependencies(
-  transformedTasks: TaskTransformed[],
+  taskById: Map<string, TaskTransformed>,
   liveOffsets: Record<string, DragOffset>
 ): RenderedDependency[] {
   const dependencies: RenderedDependency[] = [];
 
-  for (const currentTask of transformedTasks) {
+  for (const currentTask of taskById.values()) {
     const sourceOffset = liveOffsets[currentTask.id] ?? NO_OFFSET;
 
     for (const dep of currentTask.dependencies ?? []) {
-      const targetTask = transformedTasks.find((t) => t.id === dep.targetId);
+      const targetTask = taskById.get(dep.targetId);
       if (!targetTask) continue;
 
       const coords = calculateArrowCoords(

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -7,7 +7,13 @@ import {
   NODE_HEIGHT,
 } from 'constants/gantt';
 import { normalizeProgress, type Task, type TaskTransformed } from 'types/task';
-import { buildDependencies, getSmartGanttPath } from './arrowPath';
+import {
+  buildDependencies,
+  buildTaskIndex,
+  getSmartGanttPath,
+  isArrowVisible,
+  type ArrowViewport,
+} from './arrowPath';
 import { mergeHeaderGroups } from './headerUtils';
 import {
   calculateDateOffsetPx,
@@ -235,16 +241,23 @@ describe('buildDependencies', () => {
     originalOrder: order,
     ...extra,
   });
-  const chain = (extra: Partial<TaskTransformed> = {}) => [
-    bar('a', 1, 100, extra),
-    bar('b', 2, 300, { dependencies: [{ targetId: 'a', type: 'FS' }] }),
-  ];
+  const chain = (extra: Partial<TaskTransformed> = {}) =>
+    buildTaskIndex([
+      bar('a', 1, 100, extra),
+      bar('b', 2, 300, { dependencies: [{ targetId: 'a', type: 'FS' }] }),
+    ]);
   const center = NODE_HEIGHT / 2;
 
   it('anchors an FS arrow from the predecessor end to the successor start', () => {
     expect(buildDependencies(chain(), {})).toEqual([
       { targetId: 'a', type: 'FS', fromX: 164, fromY: center, toX: 300, toY: NODE_HEIGHT + center },
     ]);
+  });
+
+  it('indexes tasks by id and keeps task order for iteration', () => {
+    const index = buildTaskIndex([bar('a', 1, 100), bar('b', 2, 300)]);
+    expect([...index.keys()]).toEqual(['a', 'b']);
+    expect(index.get('b')?.barLeft).toBe(300);
   });
 
   it('follows the live offset of whichever end is being dragged', () => {
@@ -275,11 +288,11 @@ describe('buildDependencies', () => {
     const unknownDep = [
       { targetId: 'a', type: 'fs' },
     ] as unknown as TaskTransformed['dependencies'];
-    const tasks = [
+    const tasks = buildTaskIndex([
       bar('a', 1, 100),
       bar('b', 2, 300, { dependencies: unknownDep }),
       bar('c', 3, 500, { dependencies: unknownDep }),
-    ];
+    ]);
 
     expect(buildDependencies(tasks, {})).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
@@ -288,8 +301,52 @@ describe('buildDependencies', () => {
 
   it('skips dependencies pointing at a task that is not in the chart', () => {
     expect(
-      buildDependencies([bar('b', 1, 300, { dependencies: [{ targetId: 'gone', type: 'FS' }] })], {}),
+      buildDependencies(
+        buildTaskIndex([
+          bar('b', 1, 300, { dependencies: [{ targetId: 'gone', type: 'FS' }] }),
+        ]),
+        {},
+      ),
     ).toEqual([]);
+  });
+});
+
+describe('isArrowVisible', () => {
+  // 가로 100~500, 세로 100~300 이 보이는 상황
+  const viewport: ArrowViewport = {
+    topPx: 100,
+    bottomPx: 300,
+    isBarVisible: (left, width) => left + width >= 100 && left <= 500,
+  };
+  const arrow = (fromX: number, fromY: number, toX: number, toY: number) => ({
+    fromX,
+    fromY,
+    toX,
+    toY,
+  });
+
+  it('keeps arrows that overlap the viewport', () => {
+    expect(isArrowVisible(arrow(200, 150, 300, 250), viewport)).toBe(true);
+  });
+
+  it('drops arrows fully above, below, left of, or right of the viewport', () => {
+    expect(isArrowVisible(arrow(200, 0, 300, 40), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(200, 400, 300, 450), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(0, 150, 40, 250), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(600, 150, 700, 250), viewport)).toBe(false);
+  });
+
+  it('keeps an arrow whose ends straddle the viewport on either axis', () => {
+    // 위/아래 끝이 모두 화면 밖이지만 선이 화면을 세로로 관통한다
+    expect(isArrowVisible(arrow(200, 0, 300, 500), viewport)).toBe(true);
+    // 좌/우도 마찬가지
+    expect(isArrowVisible(arrow(0, 150, 900, 250), viewport)).toBe(true);
+  });
+
+  it('allows for the elbow overshooting the endpoints', () => {
+    // 꺾인 경로가 끝점 바깥으로 조금 나가므로 경계 근처는 살려 둔다
+    expect(isArrowVisible(arrow(80, 150, 90, 250), viewport)).toBe(true);
+    expect(isArrowVisible(arrow(200, 60, 300, 80), viewport)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #26

Three things were making a large chart expensive to render, all of them paid on every drag frame.

**Dependency lookup was quadratic.** `buildDependencies` resolved each link's target with a linear scan over the whole task array, inside a loop over the whole task array. On a 1,000-task chart that is roughly a million id comparisons per rebuild, and a rebuild happens on every pointer move during a drag. It now takes a `Map<id, task>` built once per data change (`buildTaskIndex`, memoized in the arrows component) and uses it both as the iteration source and as the lookup index, so the same pass is linear.

**Arrows were never culled.** Rows have been virtualized for a while, but every dependency in the dataset rendered every frame regardless of where the viewport was — that, not the rows, was the real scaling ceiling. `isArrowVisible` now drops an arrow whose bounding box misses the visible window. The vertical range comes from the row virtualizer and the horizontal test reuses the `isBarVisible` helper the bars already use, so arrows and bars are cut on exactly the same window and an arrow can never survive its own bar. Because the test is a box intersection rather than an endpoint test, an arrow whose two ends are both off-screen but whose line crosses the viewport still draws — measured below. A 32px bleed covers the elbow overshoot so nothing pops at the edges.

**The header ignored the column virtualizer.** `useGanttVirtualization` returned a `columnVirtualizer` that nothing consumed while `GanttChartHeader` mapped over every bottom-row cell. The column virtualizer is now split into `useGanttColumnVirtualization` and the header renders only the cells it reports, preceded by a spacer div for the skipped leading width, which keeps the existing flex layout and needs no CSS change. The top group row is a small merged list and is untouched.

### Measurements

Chrome via Playwright, dev build, demo dataset temporarily grown to 1,000 tasks / 1,039 dependencies spanning 1,000 days (that change is not part of this diff). "Drag frame" is dispatch of a synthetic `pointermove` that crosses a drag step, plus React's commit, plus a forced style/layout — 45 moves, first 5 dropped, month scale.

At month scale, scrolled to the top:

| | before | after |
|---|---|---|
| `path.gantt-dependency-arrow` | 1,038 | 73 |
| `.gantt-bottom-cell` | 1,013 | 61 |
| chart DOM nodes | 2,487 | 571 |
| drag frame mean | 10.0 ms | 2.9 ms |
| drag frame p95 | 11.7 ms | 3.5 ms |

Same dataset, scrolled to the middle (row ~500, x 16,000) — the case a user actually works in:

| | before | after |
|---|---|---|
| arrows | 1,038 | 61 |
| bottom cells | 1,013 | 66 |
| drag frame mean | 11.4 ms | 1.0 ms |
| drag frame p95 | 24.8 ms | 1.5 ms |

At day scale over the same range the header is where it hurts: 24,058 ticks in range, so 24,058 cell nodes before and 61 after; the whole chart goes from 27,316 DOM nodes to 2,323, and switching to day scale drops from 3,469 ms to 242 ms.

### Correctness

At the default zoom on the demo dataset all 22 rendered arrows anchor to the right bar edge at the right row centre. Scrolling right culls them down to 1 and scrolling back restores all 22, and the header cells follow. Scrolled to the middle of the 1,000-task set, 19 of the 61 surviving arrows have both endpoints outside the viewport and are kept because their line crosses it. Bottom-row cells stay on the 32px grid and the row keeps its full scroll width, so the header, the weekend shading and the bars stay aligned.

`pnpm lint` (0 errors, the same 4 warnings as before), `pnpm type-check`, `pnpm test` (39 passing, 5 new) and `pnpm build` all pass. New unit tests cover the Map-based build and the culling predicate, including the straddle case and the bleed margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
