### PR TITLE
fix(ci): accept forwardRef components in the SSR smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
       - run: pnpm build
       # SSR safety: importing and server-rendering the built package in plain Node
       # (no DOM globals) must not touch window/document/sessionStorage.
+      # forwardRef/memo 컴포넌트는 함수가 아니라 객체다 - 존재 여부만 확인하고
+      # 실제 동작은 아래 renderToString이 검증한다
       - name: SSR import smoke test
         run: |
-          node --input-type=module -e "const m = await import('@jaeungkim/gantt-chart'); if (typeof m.ReactGanttChart !== 'function') throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (esm)');"
-          node --input-type=commonjs -e "const m = require('@jaeungkim/gantt-chart'); if (typeof m.ReactGanttChart !== 'function') throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (cjs)');"
+          node --input-type=module -e "const m = await import('@jaeungkim/gantt-chart'); if (!m.ReactGanttChart) throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (esm)');"
+          node --input-type=commonjs -e "const m = require('@jaeungkim/gantt-chart'); if (!m.ReactGanttChart) throw new Error('missing ReactGanttChart export'); console.log('SSR import OK (cjs)');"
           node --input-type=module -e "const { createElement } = await import('react'); const { renderToString } = await import('react-dom/server'); const { ReactGanttChart } = await import('@jaeungkim/gantt-chart'); const html = renderToString(createElement(ReactGanttChart, { tasks: [{ id: '1', name: 'A', startDate: '2025-01-01', endDate: '2025-01-05', parentId: null, sequence: '1' }] })); if (!html.includes('gantt-container')) throw new Error('SSR render produced no chart markup'); console.log('SSR render OK');"


### PR DESCRIPTION
The SSR smoke test asserted `typeof m.ReactGanttChart === 'function'`. Wrapping the component in `forwardRef` (for the scroll API in #93) makes the export an object — `{$$typeof: Symbol(react.forward_ref), render: fn}` — so the assertion failed even though the export is present and renders correctly.

The check now asserts the export exists; the `renderToString` step that follows already proves it actually renders, which is the property worth testing.

Verified locally against the built package: `typeof` is `object`, and `renderToString` produces markup containing `gantt-container`.

This unblocks `main`, which is currently red for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)