### PR TITLE
perf: cull arrows and header cells; fix DST drag math; translate comments to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Currently, this project is built specifically for React due to my development ba
   - Resize from left/right edges
   - Snap to configured intervals
 - 🧲 Smart dependency arrows (FS, SS, FF, SF)
+- ◆ Milestones and per-task progress
+- 🗓️ Weekend and holiday shading
 - ⚡ Virtualized rendering for performance
 - 🌙 Light/Dark/System theme support
 - 📍 Today marker indicator
@@ -95,6 +97,10 @@ export default function App() {
 | `theme` | `"light" \| "dark" \| "system"` | - | Theme mode |
 | `defaultScale` | `"day" \| "week" \| "month" \| "year"` | `"month"` | Initial timeline scale |
 | `className` | `string` | - | Additional CSS class for the container |
+| `showNonWorkingDays` | `boolean` | `true` | Shade weekends and holidays at day/week scales |
+| `holidays` | `string[]` | - | Extra non-working dates, `YYYY-MM-DD` |
+| `isNonWorkingDay` | `(date: Dayjs) => boolean` | - | Replaces the default weekend/holiday check entirely |
+| `storageKey` | `string` | `"gantt-scale"` | sessionStorage key for the scale. Give each chart its own key when rendering more than one on a page. |
 
 ## Task Format
 
@@ -108,6 +114,8 @@ interface Task {
   endDate: string;      // UTC ISO string
   parentId: string | null;
   sequence: string;
+  type?: 'task' | 'milestone';   // milestones render as a diamond at startDate
+  progress?: number;             // 0-100, draws a fill inside the bar
   dependencies?: TaskDependency[];
 }
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ type DependencyType = 'FS' | 'SS' | 'FF' | 'SF';
 // SF = Start-to-Finish
 ```
 
+### Time zone
+
+**The chart draws and labels the timeline in UTC.** The grid, the bars, the tick and header
+labels, and the drag tooltips all use UTC, so the same tasks render identically for every
+viewer — a chart shared between Seoul and London puts every bar on the same day cell.
+`onTasksChange` hands back UTC ISO strings (`2024-06-01T09:00:00.000Z`).
+
+- A string with a zone (`"2024-06-01T09:00:00Z"`, `"2024-06-01T18:00:00+09:00"`) is that
+  instant, shown at its UTC clock time — both examples render at `09:00`.
+- A string without a zone (`"2024-06-01"`, `"2024-06-01T09:00"`) is read as UTC wall clock,
+  so it renders exactly as written and lands on the day it names, wherever the viewer is.
+
+`holidays` entries are UTC days too, and the `Dayjs` handed to `isNonWorkingDay` is in UTC mode,
+so `date.day()` inside it is the UTC weekday.
+
+Want the chart to read in your own zone instead? Convert to that zone's wall clock and drop
+the offset before passing the tasks in (e.g. `"2024-06-01T18:00"` for 18:00 KST), and convert
+back in `onTasksChange`. There is no per-viewer local-time mode: local rendering would move
+bars between day cells depending on where the viewer sits, and local DST days (23 or 25 hours
+long) would make a one-day drag land an hour off the day it was dropped on.
+
 ## Timeline Scales
 
 | Scale | Header Label | Tick Unit | Drag Step |

--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -2,27 +2,27 @@
 /* Minimal & Clean Design */
 
 /* ===== DESIGN TOKENS =====
-   모든 토큰은 --gantt-* 접두사 + .gantt-container 스코프.
-   :root에 두면 호스트 앱의 --background/--border 등과 충돌한다.
-   폰트는 번들에 포함하지 않는다 - 호스트가 --gantt-font-sans를 덮어쓰면 된다. */
+   Every token is prefixed --gantt-* and scoped to .gantt-container.
+   On :root they would collide with the host app's --background/--border and friends.
+   Fonts are not bundled - the host can override --gantt-font-sans. */
 .gantt-container {
-  /* 타이포그래피 */
+  /* Typography */
   --gantt-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Geist",
     system-ui, sans-serif;
 
-  /* 배경 */
+  /* Background */
   --gantt-background: #fafafa;
   --gantt-foreground: #18181b;
 
-  /* 뮤트 */
+  /* Muted */
   --gantt-muted: #f4f4f5;
   --gantt-muted-foreground: #71717a;
 
-  /* 보더 */
+  /* Border */
   --gantt-border: #e4e4e7;
   --gantt-border-subtle: rgba(0, 0, 0, 0.04);
 
-  /* 태스크 바 */
+  /* Task bar */
   --gantt-bar-bg: #e4e4e7;
   --gantt-bar-bg-hover: #d4d4d8;
   --gantt-bar-text: #18181b;
@@ -30,33 +30,33 @@
   --gantt-bar-shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
   --gantt-bar-shadow-drag: 0 8px 24px rgba(0, 0, 0, 0.15);
 
-  /* 의존성 화살표 */
+  /* Dependency arrows */
   --gantt-arrow: #a1a1aa;
 
-  /* 액센트 */
+  /* Accent */
   --gantt-accent: #3b82f6;
 
-  /* 오늘 마커 */
+  /* Today marker */
   --gantt-today-marker: #f43f5e;
 
-  /* 마일스톤 */
+  /* Milestone */
   --gantt-milestone-bg: #52525b;
   --gantt-milestone-bg-hover: #3f3f46;
 
-  /* 진행률 */
+  /* Progress */
   --gantt-progress-bg: #a1a1aa;
   --gantt-progress-handle: #52525b;
 
-  /* 비근무일 음영 */
+  /* Non-working-day shading */
   --gantt-non-working-bg: rgba(0, 0, 0, 0.035);
 
-  /* 트랜지션 */
+  /* Transitions */
   --gantt-duration-fast: 150ms;
   --gantt-transition-fast: 150ms ease;
   --gantt-transition-normal: 200ms ease;
 }
 
-/* 다크 테마 */
+/* Dark theme */
 .gantt-container.dark,
 .gantt-container[data-theme="dark"] {
   --gantt-background: #09090b;
@@ -88,7 +88,7 @@
   --gantt-non-working-bg: rgba(255, 255, 255, 0.03);
 }
 
-/* 테마 prop이 없을 때는 OS 설정을 따른다 (명시적 light 지정은 유지) */
+/* With no theme prop, follow the OS setting (an explicit light choice is kept) */
 @media (prefers-color-scheme: dark) {
   .gantt-container:not(.light):not([data-theme="light"]) {
     --gantt-background: #09090b;
@@ -121,9 +121,9 @@
   }
 }
 
-/* 컨테이너 안에서만 border-box를 강제한다.
-   호스트 앱의 리셋 유무와 무관하게 레이아웃 계산이 같아야 하고,
-   전역 리셋을 내보내면 호스트 스타일을 침범한다. */
+/* border-box is forced only inside the container.
+   Layout math has to come out the same whether or not the host app ships a reset,
+   and exporting a global reset would trample the host's styles. */
 .gantt-container,
 .gantt-container *,
 .gantt-container *::before,
@@ -248,7 +248,7 @@
   white-space: nowrap;
 }
 
-/* 표준 속성 우선 (Chrome 121+, Firefox). 지원하지 않는 브라우저만 아래 webkit 규칙 사용 */
+/* Prefer the standard properties (Chrome 121+, Firefox). Only browsers without support fall back to the webkit rules below */
 .gantt-scroll-container {
   scrollbar-width: thin;
   scrollbar-color: var(--gantt-border) transparent;
@@ -319,7 +319,7 @@
   color: var(--gantt-foreground);
 }
 
-/* 그룹 자체가 아닌 라벨만 고정 - 다음 그룹이 들어오면 밀려나며 가리지 않음 */
+/* Pin the label, not the group itself - it slides out of the way when the next group arrives instead of covering it */
 .gantt-top-group-label {
   position: sticky;
   left: var(--top-group-inset);
@@ -368,14 +368,14 @@
   background: var(--gantt-non-working-bg);
 }
 
-/* ===== TASK ROWS (배경 전용) ===== */
+/* ===== TASK ROWS (background only) ===== */
 .gantt-rows {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  /* 배경 레이어 - 화살표/바와 같은 레이어에서 DOM 순서상 가장 먼저 그려진다 */
+  /* Background layer - on the same layer as the arrows and bars, painted first by DOM order */
   z-index: 0;
   pointer-events: none;
 }
@@ -411,8 +411,9 @@
   left: 0;
   width: 100%;
   pointer-events: none;
-  /* 바 wrapper는 transform 때문에 자체 stacking context라 바의 z-index가 밖으로 안 나온다.
-     화살표를 같은 auto/0 레이어에 두면 DOM 순서상 뒤에 오는 바가 위에 그려진다. */
+  /* The bar wrapper is its own stacking context because of the transform, so a bar's
+     z-index does not reach outside it. Keeping the arrows on the same auto/0 layer means
+     bars later in DOM order are painted on top. */
   z-index: 0;
 }
 
@@ -439,7 +440,7 @@
   user-select: none;
   cursor: grab;
   box-shadow: var(--gantt-bar-shadow);
-  /* transform 제외 - 드래그 시 inline style로 제어됨 */
+  /* transform is excluded - it is driven by inline style while dragging */
   transition: background var(--gantt-transition-fast),
     box-shadow var(--gantt-transition-normal);
 }
@@ -488,7 +489,7 @@
   opacity: 0.7;
 }
 
-/* 좁은 바: 리사이즈 핸들 숨김 (전체가 이동 핸들) */
+/* Narrow bars: hide the resize handles (the whole bar is the move handle) */
 .gantt-task-bar.compact::before,
 .gantt-task-bar.compact::after,
 .gantt-task-bar.compact:hover::before,
@@ -544,7 +545,7 @@
   pointer-events: none;
 }
 
-/* 바가 좁을 때 라벨을 바 오른쪽 바깥에 표시 */
+/* When the bar is narrow, show the label outside its right edge */
 .gantt-task-name.outside {
   position: absolute;
   left: 100%;
@@ -603,8 +604,8 @@
 }
 
 /* ===== BAR TOOLTIP ===== */
-/* 바 아래에 표시한다 - 위에 두면 최상단 행에서 sticky 헤더에 가려진다
-   (툴팁은 두 겹의 transform 스태킹 컨텍스트 안이라 z-index로는 헤더를 넘지 못한다) */
+/* Shown below the bar - above it, the sticky header would cover it on the topmost row
+   (the tooltip sits inside two nested transform stacking contexts, so no z-index lifts it over the header) */
 .gantt-bar-tooltip {
   position: absolute;
   top: calc(100% + 8px);
@@ -621,7 +622,7 @@
   white-space: nowrap;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   pointer-events: none;
-  /* 지속시간 토큰만 사용 - transition 토큰은 easing을 포함해 shorthand가 무효가 된다 */
+  /* Duration token only - the transition tokens carry easing, which would invalidate this shorthand */
   animation: tooltipFadeIn var(--gantt-duration-fast) ease-out;
 }
 

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -10,7 +10,7 @@ import {
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
 import { useGanttProgressDrag } from "hooks/useGanttProgressDrag";
 import { useRef, useState, useCallback } from "react";
-import { useGanttStore } from "stores/store";
+import { useGanttStore } from "stores/context";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 
 interface GanttBarProps {

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -26,7 +26,7 @@ export default function GanttBar({
   const { onPointerDown, dragMode } = useGanttBarDrag(currentTask, onTasksChange);
   const [cursor, setCursor] = useState<"grab" | "ew-resize">("grab");
 
-  // 드래그 오프셋 가져오기
+  // Read the drag offset
   const liveOffset = useGanttStore((store) => store.dragOffsets[currentTask.id]);
   const isDragging = useGanttStore((store) => store.currentTask?.id === currentTask.id);
   const selectedScale = useGanttStore((store) => store.selectedScale);
@@ -34,8 +34,8 @@ export default function GanttBar({
   const offsetX = liveOffset?.offsetX ?? 0;
   const offsetWidth = liveOffset?.offsetWidth ?? 0;
 
-  // 최종 위치 및 크기 계산
-  // 짧은 태스크도 잡을 수 있도록 최소 너비 보장, 좁으면 라벨을 바 밖으로
+  // Final position and size
+  // Guarantee a minimum width so short tasks stay grabbable; move the label outside when narrow
   const finalLeft = currentTask.barLeft + offsetX;
   const finalWidth = Math.max(
     currentTask.barWidth + offsetWidth,
@@ -45,12 +45,12 @@ export default function GanttBar({
 
   const isMilestone = isMilestoneTask(currentTask);
 
-  // 진행률 (마일스톤은 진행률 없음)
+  // Progress (milestones have none)
   const { onProgressPointerDown, progress, isDraggingProgress } =
     useGanttProgressDrag(currentTask, barRef, onTasksChange);
   const showProgress = !isMilestone && progress !== null;
 
-  // 마우스 위치에 따른 커서 변경 (마일스톤은 리사이즈 없음)
+  // Change the cursor based on the mouse position (milestones cannot be resized)
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (isMilestone) return;
@@ -78,7 +78,7 @@ export default function GanttBar({
     [isMilestone]
   );
 
-  // 툴팁 텍스트 생성 (모드에 따라 다르게 표시)
+  // Build the tooltip text (shown differently per mode)
   const format = DATE_FORMATS[selectedScale];
   const getTooltipText = (mode: DragMode | null) => {
     if (!liveOffset) return "";
@@ -99,7 +99,7 @@ export default function GanttBar({
     }
   };
 
-  // 마일스톤: startDate 한 점에 다이아몬드 + 우측 라벨
+  // Milestone: a diamond at the single startDate point, with a label to its right
   if (isMilestone) {
     return (
       <div
@@ -114,12 +114,12 @@ export default function GanttBar({
         }}
         role="button"
         tabIndex={0}
-        aria-label={`마일스톤: ${currentTask.name}`}
+        aria-label={`Milestone: ${currentTask.name}`}
       >
         <div className="gantt-milestone-diamond" />
         <span className="gantt-milestone-name">{currentTask.name}</span>
 
-        {/* 드래그 중 툴팁 */}
+        {/* Tooltip while dragging */}
         {isDragging && liveOffset && (
           <div className="gantt-bar-tooltip" role="status" aria-live="polite">
             {getTooltipText(dragMode)}
@@ -149,11 +149,11 @@ export default function GanttBar({
       tabIndex={0}
       aria-label={
         showProgress
-          ? `태스크: ${currentTask.name}, ${progress}% 완료`
-          : `태스크: ${currentTask.name}`
+          ? `Task: ${currentTask.name}, ${progress}% complete`
+          : `Task: ${currentTask.name}`
       }
     >
-      {/* 진행률 채움 + 핸들 */}
+      {/* Progress fill + handle */}
       {showProgress && (
         <>
           <div
@@ -168,7 +168,7 @@ export default function GanttBar({
             onPointerDown={onProgressPointerDown}
             role="slider"
             tabIndex={-1}
-            aria-label={`${currentTask.name} 진행률`}
+            aria-label={`${currentTask.name} progress`}
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={progress}
@@ -182,14 +182,14 @@ export default function GanttBar({
         {currentTask.name}
       </span>
 
-      {/* 드래그 중 툴팁 */}
+      {/* Tooltip while dragging */}
       {isDragging && liveOffset && (
         <div className="gantt-bar-tooltip" role="status" aria-live="polite">
           {getTooltipText(dragMode)}
         </div>
       )}
 
-      {/* 진행률 드래그 중 툴팁 */}
+      {/* Tooltip while dragging progress */}
       {isDraggingProgress && (
         <div className="gantt-bar-tooltip" role="status" aria-live="polite">
           {progress}%

--- a/src/components/GanttChartHeader.tsx
+++ b/src/components/GanttChartHeader.tsx
@@ -1,4 +1,5 @@
 import { GANTT_SCALE_CONFIG } from "constants/gantt";
+import { useGanttColumnVirtualization } from "hooks/useGanttVirtualization";
 import React, { useMemo } from "react";
 import { GanttBottomRowCell, GanttScaleKey } from "types/gantt";
 import { mergeHeaderGroups } from "utils/headerUtils";
@@ -8,8 +9,8 @@ interface GanttChartHeaderProps {
   bottomRowCells: GanttBottomRowCell[];
   selectedScale: GanttScaleKey;
   width: number;
-  /** 사용하지 않음 - 상단 그룹 라벨 고정은 CSS sticky로 처리 */
-  scrollRef?: React.RefObject<HTMLDivElement | null>;
+  /** 하단 시간 셀 가상화용 스크롤 컨테이너 (상단 그룹 라벨 고정은 CSS sticky로 처리) */
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -20,8 +21,18 @@ function GanttChartHeader({
   bottomRowCells,
   selectedScale,
   width,
+  scrollRef,
 }: GanttChartHeaderProps) {
   const config = GANTT_SCALE_CONFIG[selectedScale];
+
+  // 하단 셀은 열 가상화 - day 스케일의 긴 범위는 셀이 수천 개다
+  // (상단 그룹은 병합된 소수의 라벨이라 그대로 그린다)
+  const { columnVirtualizer } = useGanttColumnVirtualization({
+    bottomRowCells,
+    scrollRef,
+  });
+  const virtualCells = columnVirtualizer.getVirtualItems();
+  const leadingPx = virtualCells[0]?.start ?? 0;
 
   // 헤더 그룹 생성 및 병합 (memoized)
   const topGroups = useMemo(
@@ -48,16 +59,21 @@ function GanttChartHeader({
           </div>
         </div>
 
-        {/* 하단 시간 셀 */}
+        {/* 하단 시간 셀 (가시 영역만) */}
         <div className="gantt-bottom-row">
-          {bottomRowCells.map((cell, idx) => {
+          {/* 건너뛴 앞쪽 셀들의 폭 - flex 흐름을 그대로 두려고 스페이서로 민다 */}
+          <div style={{ width: `${leadingPx}px` }} aria-hidden="true" />
+          {virtualCells.map((virtualCell) => {
+            const cell = bottomRowCells[virtualCell.index];
+            if (!cell) return null;
+
             const tickLabel = config.formatTickLabel?.(cell.startDate) || "";
 
             return (
               <div
-                key={`bottom-${idx}`}
+                key={`bottom-${virtualCell.index}`}
                 className="gantt-bottom-cell"
-                style={{ width: `${cell.widthPx}px` }}
+                style={{ width: `${virtualCell.size}px` }}
               >
                 {tickLabel}
               </div>

--- a/src/components/GanttChartHeader.tsx
+++ b/src/components/GanttChartHeader.tsx
@@ -9,13 +9,13 @@ interface GanttChartHeaderProps {
   bottomRowCells: GanttBottomRowCell[];
   selectedScale: GanttScaleKey;
   width: number;
-  /** 하단 시간 셀 가상화용 스크롤 컨테이너 (상단 그룹 라벨 고정은 CSS sticky로 처리) */
+  /** Scroll container used to virtualize the bottom time cells (pinning the top group labels is done with CSS sticky) */
   scrollRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
- * Gantt 차트 헤더 컴포넌트
- * 상단 그룹 라벨과 하단 시간 셀을 표시
+ * Gantt chart header component
+ * Renders the top group labels and the bottom time cells
  */
 function GanttChartHeader({
   bottomRowCells,
@@ -25,8 +25,8 @@ function GanttChartHeader({
 }: GanttChartHeaderProps) {
   const config = GANTT_SCALE_CONFIG[selectedScale];
 
-  // 하단 셀은 열 가상화 - day 스케일의 긴 범위는 셀이 수천 개다
-  // (상단 그룹은 병합된 소수의 라벨이라 그대로 그린다)
+  // The bottom cells are column-virtualized - a long range at day scale runs to thousands of cells
+  // (the top groups are a handful of merged labels, so they are rendered as-is)
   const { columnVirtualizer } = useGanttColumnVirtualization({
     bottomRowCells,
     scrollRef,
@@ -34,7 +34,7 @@ function GanttChartHeader({
   const virtualCells = columnVirtualizer.getVirtualItems();
   const leadingPx = virtualCells[0]?.start ?? 0;
 
-  // 헤더 그룹 생성 및 병합 (memoized)
+  // Build and merge the header groups (memoized)
   const topGroups = useMemo(
     () =>
       mergeHeaderGroups(createTopHeaderGroups(bottomRowCells, selectedScale)),
@@ -44,7 +44,7 @@ function GanttChartHeader({
   return (
     <header className="gantt-header" style={{ width: `${width}px` }}>
       <div className="gantt-header-content">
-        {/* 상단 헤더 그룹 */}
+        {/* Top header groups */}
         <div className="gantt-top-header">
           <div className="gantt-top-groups">
             {topGroups.map((group, idx) => (
@@ -59,9 +59,9 @@ function GanttChartHeader({
           </div>
         </div>
 
-        {/* 하단 시간 셀 (가시 영역만) */}
+        {/* Bottom time cells (visible area only) */}
         <div className="gantt-bottom-row">
-          {/* 건너뛴 앞쪽 셀들의 폭 - flex 흐름을 그대로 두려고 스페이서로 민다 */}
+          {/* Width of the skipped leading cells - pushed out with a spacer to leave the flex flow intact */}
           <div style={{ width: `${leadingPx}px` }} aria-hidden="true" />
           {virtualCells.map((virtualCell) => {
             const cell = bottomRowCells[virtualCell.index];

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -1,8 +1,15 @@
 import { NODE_HEIGHT } from "constants/gantt";
-import { useId } from "react";
+import { useGanttVirtualization } from "hooks/useGanttVirtualization";
+import { useCallback, useId, useMemo, useRef } from "react";
 import { useGanttStore } from "stores/context";
 import { TaskTransformed } from "types/task";
-import { buildDependencies, getSmartGanttPath } from "utils/arrowPath";
+import {
+  ArrowViewport,
+  buildDependencies,
+  buildTaskIndex,
+  getSmartGanttPath,
+  isArrowVisible,
+} from "utils/arrowPath";
 
 interface Props {
   transformedTasks: TaskTransformed[];
@@ -12,7 +19,41 @@ export default function GanttDependencyArrows({
   transformedTasks,
 }: Props) {
   const liveOffsets = useGanttStore((store) => store.dragOffsets);
-  const dependencies = buildDependencies(transformedTasks, liveOffsets);
+  const bottomRowCells = useGanttStore((store) => store.bottomRowCells);
+
+  // 스크롤 컨테이너는 SVG의 조상이라 마운트 시 직접 찾는다.
+  // 바 컬링과 같은 가상화 창을 써야 화살표만 먼저 잘리는 일이 없다.
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const attachSvg = useCallback((svg: SVGSVGElement | null) => {
+    scrollRef.current =
+      svg?.closest<HTMLDivElement>(".gantt-scroll-container") ?? null;
+  }, []);
+
+  const { rowVirtualizer, isBarVisible } = useGanttVirtualization({
+    transformedTasks,
+    bottomRowCells,
+    scrollRef,
+  });
+
+  // 태스크 인덱스는 데이터가 바뀔 때만 다시 만든다 (드래그 프레임마다가 아니라)
+  const taskById = useMemo(
+    () => buildTaskIndex(transformedTasks),
+    [transformedTasks]
+  );
+
+  // 화면 밖 화살표는 만들지 않는다 - 행은 이미 가상화되어 있어서
+  // 대량 데이터에서는 화살표가 실질적인 한계였다
+  const visibleRows = rowVirtualizer.getVirtualItems();
+  const lastRow = visibleRows[visibleRows.length - 1];
+  const viewport: ArrowViewport = {
+    topPx: visibleRows[0]?.start ?? 0,
+    bottomPx: lastRow ? lastRow.start + lastRow.size : 0,
+    isBarVisible,
+  };
+
+  const dependencies = buildDependencies(taskById, liveOffsets).filter((dep) =>
+    isArrowVisible(dep, viewport)
+  );
 
   // marker id는 문서 전역이라 인스턴스마다 고유해야 차트를 여러 개 띄워도 안 섞인다
   // useId 값에는 url(#...) 참조에 부적합한 문자가 섞이므로 영숫자만 남긴다
@@ -21,6 +62,7 @@ export default function GanttDependencyArrows({
 
   return (
     <svg
+      ref={attachSvg}
       className="gantt-dependency-arrows"
       style={{
         height: `${transformedTasks.length * NODE_HEIGHT}px`,

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -1,6 +1,6 @@
 import { NODE_HEIGHT } from "constants/gantt";
 import { useId } from "react";
-import { useGanttStore } from "stores/store";
+import { useGanttStore } from "stores/context";
 import { TaskTransformed } from "types/task";
 import { buildDependencies, getSmartGanttPath } from "utils/arrowPath";
 

--- a/src/components/GanttDependencyArrows.tsx
+++ b/src/components/GanttDependencyArrows.tsx
@@ -21,8 +21,9 @@ export default function GanttDependencyArrows({
   const liveOffsets = useGanttStore((store) => store.dragOffsets);
   const bottomRowCells = useGanttStore((store) => store.bottomRowCells);
 
-  // 스크롤 컨테이너는 SVG의 조상이라 마운트 시 직접 찾는다.
-  // 바 컬링과 같은 가상화 창을 써야 화살표만 먼저 잘리는 일이 없다.
+  // The scroll container is an ancestor of the SVG, so it is looked up on mount.
+  // Using the same virtualization window as the bar culling keeps arrows from being
+  // culled ahead of the bars.
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const attachSvg = useCallback((svg: SVGSVGElement | null) => {
     scrollRef.current =
@@ -35,14 +36,14 @@ export default function GanttDependencyArrows({
     scrollRef,
   });
 
-  // 태스크 인덱스는 데이터가 바뀔 때만 다시 만든다 (드래그 프레임마다가 아니라)
+  // The task index is rebuilt only when the data changes (not on every drag frame)
   const taskById = useMemo(
     () => buildTaskIndex(transformedTasks),
     [transformedTasks]
   );
 
-  // 화면 밖 화살표는 만들지 않는다 - 행은 이미 가상화되어 있어서
-  // 대량 데이터에서는 화살표가 실질적인 한계였다
+  // Arrows outside the viewport are never built - the rows are already virtualized, so on
+  // large data sets the arrows were the real limit
   const visibleRows = rowVirtualizer.getVirtualItems();
   const lastRow = visibleRows[visibleRows.length - 1];
   const viewport: ArrowViewport = {
@@ -55,8 +56,10 @@ export default function GanttDependencyArrows({
     isArrowVisible(dep, viewport)
   );
 
-  // marker id는 문서 전역이라 인스턴스마다 고유해야 차트를 여러 개 띄워도 안 섞인다
-  // useId 값에는 url(#...) 참조에 부적합한 문자가 섞이므로 영숫자만 남긴다
+  // Marker ids are document-global, so each instance needs its own or several charts on a
+  // page would mix them up
+  // useId values contain characters that are invalid in a url(#...) reference, so only
+  // alphanumerics are kept
   const instanceId = useId().replace(/[^a-zA-Z0-9]/g, "");
   const arrowheadId = `gantt-arrowhead-${instanceId}`;
 

--- a/src/components/GanttDragGuides.tsx
+++ b/src/components/GanttDragGuides.tsx
@@ -1,5 +1,5 @@
 import { DATE_FORMATS } from "constants/gantt";
-import { useGanttStore } from "stores/store";
+import { useGanttStore } from "stores/context";
 import { isMilestoneTask } from "types/task";
 
 interface GanttDragGuidesProps {

--- a/src/components/GanttDragGuides.tsx
+++ b/src/components/GanttDragGuides.tsx
@@ -7,8 +7,8 @@ interface GanttDragGuidesProps {
 }
 
 /**
- * 드래그 중 시작/종료 지점을 헤더까지 관통하는 세로 가이드로 표시
- * 각 가이드 상단에 현재 날짜 라벨을 붙여 헤더에서 시점을 바로 읽을 수 있게 한다
+ * Shows the start/end points during a drag as vertical guides running up through the header
+ * Each guide carries the current date label at its top, so the moment can be read straight off the header
  */
 export default function GanttDragGuides({ width }: GanttDragGuidesProps) {
   const currentTask = useGanttStore((store) => store.currentTask);

--- a/src/components/ScaleSelector.tsx
+++ b/src/components/ScaleSelector.tsx
@@ -10,20 +10,20 @@ interface ScaleSelectorProps {
 const SCALE_OPTIONS = Object.keys(GANTT_SCALE_CONFIG) as GanttScaleKey[];
 
 /**
- * Gantt 차트 스케일 선택 세그먼트 컨트롤 컴포넌트
- * 드롭다운 대신 pill-style 버튼 그룹 사용
+ * Segmented control for choosing the Gantt chart scale
+ * Uses a pill-style button group instead of a dropdown
  */
 export default function ScaleSelector({
   selectedScale,
   onScaleChange,
 }: ScaleSelectorProps) {
-  // roving tabindex - 탭 대상은 선택된 옵션 하나뿐이므로 방향키로 선택을 옮길 때
-  // 포커스도 함께 옮겨야 다음 키 입력이 새 옵션 기준으로 동작한다
+  // roving tabindex - only the selected option is a tab stop, so moving the selection with
+  // the arrow keys has to move focus too, or the next key press would act on the old option
   const buttonRefs = useRef<Partial<Record<GanttScaleKey, HTMLButtonElement>>>(
     {}
   );
 
-  // 기준 인덱스는 눌린 버튼이 아니라 현재 선택된 옵션에서 가져온다
+  // The reference index comes from the currently selected option, not from the button that was pressed
   const moveSelection = (step: number) => {
     const currentIndex = SCALE_OPTIONS.indexOf(selectedScale);
     const nextIndex =
@@ -48,7 +48,7 @@ export default function ScaleSelector({
     <div
       className="gantt-scale-selector"
       role="group"
-      aria-label="타임라인 스케일 선택"
+      aria-label="Timeline scale"
     >
       <div className="gantt-scale-control">
         {SCALE_OPTIONS.map((scale) => {

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -2,22 +2,22 @@ import { GanttScaleConfig, GanttScaleKey } from 'types/gantt';
 
 export const NODE_HEIGHT = 38;
 export const TIMELINE_SHIFT_BUFFER = 5;
-/** 바가 좁아도 최소한 이 너비로 렌더링 (px) - 짧은 태스크도 잡을 수 있게 */
+/** Bars render at least this wide, however narrow they are (px) - keeps short tasks grabbable */
 export const MIN_BAR_WIDTH = 14;
-/** 이 너비 미만이면 태스크명을 바 바깥에 표시 (px) */
+/** Below this width the task name is shown outside the bar (px) */
 export const MIN_LABEL_INSIDE_WIDTH = 56;
-/** 리사이즈 엣지 감지 영역 (px) */
+/** Size of the resize edge hit area (px) */
 export const EDGE_THRESHOLD = 8;
-/** 바 너비가 이 값 미만이면 엣지 리사이즈 없이 전체를 이동 핸들로 사용 (px) */
+/** Below this bar width there is no edge resizing and the whole bar is the move handle (px) */
 export const MIN_RESIZABLE_WIDTH = EDGE_THRESHOLD * 3;
-/** 마일스톤 다이아몬드 한 변 길이 (px, 45도 회전 전) */
+/** Side length of the milestone diamond (px, before the 45-degree rotation) */
 export const MILESTONE_SIZE = 16;
-/** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
+/** Horizontal distance from the diamond's center to its vertex (px) */
 export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
 /**
- * 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제
- * 차트는 UTC로 그리므로 시각이 보이는 day 스케일에만 존을 표기한다
+ * Date display format per scale (shared by the tooltip and the drag guides) - year included, 24-hour clock
+ * The chart is drawn in UTC, so the zone is spelled out only on the day scale, where the time is visible
  */
 export const DATE_FORMATS: Record<GanttScaleKey, string> = {
   day: 'MMM D, YYYY HH:mm [UTC]',
@@ -34,7 +34,7 @@ export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
     dragStepUnit: 'hour',
     dragStepAmount: 1,
     basePxPerDragStep: 32,
-    // 12시간제는 오전/오후 구분이 없어 하루에 같은 라벨이 두 번 나옴 - 24시간제 사용
+    // A 12-hour clock has no AM/PM marker here, so the same label would appear twice a day - use 24-hour
     formatTickLabel: (d) => d.format('HH'),
     formatHeaderLabel: (d) => d.format('MMM D, YYYY'),
   },
@@ -59,7 +59,7 @@ export const GANTT_SCALE_CONFIG: Record<GanttScaleKey, GanttScaleConfig> = {
     formatHeaderLabel: (d) => d.format('MMM YYYY'),
   },
   year: {
-    // 틱이 월 단위라 상단은 연도, 하단은 월 - 하단에 일(D)을 쓰면 항상 '1'만 나옴
+    // Ticks are months, so the top row is the year and the bottom the month - a day (D) on the bottom would always print '1'
     labelUnit: 'year',
     tickUnit: 'month',
     unitPerTick: 1,

--- a/src/constants/gantt.ts
+++ b/src/constants/gantt.ts
@@ -15,9 +15,12 @@ export const MILESTONE_SIZE = 16;
 /** 다이아몬드 중심에서 꼭짓점까지의 가로 거리 (px) */
 export const MILESTONE_HALF_DIAGONAL = Math.round((MILESTONE_SIZE * Math.SQRT2) / 2);
 
-/** 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제 */
+/**
+ * 스케일별 날짜 표시 포맷 (툴팁, 드래그 가이드 공용) - 연도 포함, 24시간제
+ * 차트는 UTC로 그리므로 시각이 보이는 day 스케일에만 존을 표기한다
+ */
 export const DATE_FORMATS: Record<GanttScaleKey, string> = {
-  day: 'MMM D, YYYY HH:mm',
+  day: 'MMM D, YYYY HH:mm [UTC]',
   week: 'MMM D, YYYY',
   month: 'MMM D, YYYY',
   year: 'MMM YYYY',

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -3,11 +3,13 @@ import {
   GANTT_SCALE_CONFIG,
   MIN_RESIZABLE_WIDTH,
 } from "constants/gantt";
+import { Dayjs } from "dayjs";
 import { useRef } from "react";
 import { useGanttStore, useGanttStoreApi } from "stores/context";
-import { GanttDragOffset } from "types/gantt";
+import { GanttDragOffset, GanttScaleKey } from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
+import { shiftByDragSteps } from "utils/timeline";
 
 export type DragMode = "bar" | "left" | "right";
 
@@ -15,24 +17,15 @@ interface DragContext {
   mode: DragMode;
   pointerId: number;
   initialClientX: number;
-  initialStartDate: dayjs.Dayjs;
-  initialEndDate: dayjs.Dayjs;
+  initialStartDate: Dayjs;
+  initialEndDate: Dayjs;
   initialBarWidth: number;
   dragSteps: number;
   basePxPerDragStep: number;
-  dragStepAmount: number;
-  dragStepUnit: string;
+  // 드래그 도중 스케일이 바뀌어도 시작 시점의 스텝 단위로 계산한다
+  scaleKey: GanttScaleKey;
   taskId: string;
 }
-
-// 시간 단위 변환 상수
-const TIME_UNIT_MULTIPLIERS = {
-  minute: 1,
-  hour: 60,
-  day: 60 * 24,
-  week: 60 * 24 * 7,
-  month: 60 * 24 * 30,
-} as const;
 
 /**
  * Gantt 바 드래그 기능을 제공하는 훅
@@ -48,8 +41,7 @@ export function useGanttBarDrag(
   onTasksChangeRef.current = onTasksChange;
 
   const selectedScale = useGanttStore((s) => s.selectedScale);
-  const scaleConfig = GANTT_SCALE_CONFIG[selectedScale];
-  const { basePxPerDragStep, dragStepAmount, dragStepUnit } = scaleConfig;
+  const { basePxPerDragStep } = GANTT_SCALE_CONFIG[selectedScale];
 
   // 드래그 모드 감지
   // 마일스톤과 좁은 바는 리사이즈 불가 - 엣지 영역이 바 전체를 덮어 이동이 막히는 것을 방지
@@ -84,8 +76,7 @@ export function useGanttBarDrag(
       initialBarWidth: task.barWidth,
       dragSteps: 0,
       basePxPerDragStep,
-      dragStepAmount,
-      dragStepUnit,
+      scaleKey: selectedScale,
       taskId: task.id,
     };
 
@@ -112,24 +103,23 @@ export function useGanttBarDrag(
       ctx.dragSteps = steps;
 
       const draggedPx = steps * ctx.basePxPerDragStep;
-      const minutesPerStep = ctx.dragStepAmount * TIME_UNIT_MULTIPLIERS[ctx.dragStepUnit as keyof typeof TIME_UNIT_MULTIPLIERS];
-      const totalMinutes = steps * minutesPerStep;
+      const shift = (date: Dayjs) => shiftByDragSteps(date, steps, ctx.scaleKey);
 
-      let newStartDate: dayjs.Dayjs;
-      let newEndDate: dayjs.Dayjs;
+      let newStartDate: Dayjs;
+      let newEndDate: Dayjs;
       let offsetX = 0;
       let offsetWidth = 0;
 
       switch (ctx.mode) {
         case "bar":
-          newStartDate = ctx.initialStartDate.add(totalMinutes, "minute");
-          newEndDate = ctx.initialEndDate.add(totalMinutes, "minute");
+          newStartDate = shift(ctx.initialStartDate);
+          newEndDate = shift(ctx.initialEndDate);
           offsetX = draggedPx;
           offsetWidth = 0;
           break;
 
         case "left":
-          newStartDate = ctx.initialStartDate.add(totalMinutes, "minute");
+          newStartDate = shift(ctx.initialStartDate);
           newEndDate = ctx.initialEndDate;
           offsetX = draggedPx;
           offsetWidth = -draggedPx;
@@ -137,7 +127,7 @@ export function useGanttBarDrag(
 
         case "right":
           newStartDate = ctx.initialStartDate;
-          newEndDate = ctx.initialEndDate.add(totalMinutes, "minute");
+          newEndDate = shift(ctx.initialEndDate);
           offsetX = 0;
           offsetWidth = draggedPx;
           break;
@@ -195,8 +185,8 @@ export function useGanttBarDrag(
       }
 
       const currentRawTasks = storeApi.getState().rawTasks;
-      const minutesPerStep = ctx.dragStepAmount * TIME_UNIT_MULTIPLIERS[ctx.dragStepUnit as keyof typeof TIME_UNIT_MULTIPLIERS];
-      const totalMinutes = ctx.dragSteps * minutesPerStep;
+      const commit = (date: string) =>
+        shiftByDragSteps(dayjs(date), ctx.dragSteps, ctx.scaleKey).toISOString();
 
       const updatedTasks = currentRawTasks.map((t) => {
         if (t.id !== ctx.taskId) return t;
@@ -205,20 +195,20 @@ export function useGanttBarDrag(
           case "bar":
             return {
               ...t,
-              startDate: dayjs(t.startDate).add(totalMinutes, "minute").toISOString(),
-              endDate: dayjs(t.endDate).add(totalMinutes, "minute").toISOString(),
+              startDate: commit(t.startDate),
+              endDate: commit(t.endDate),
             };
 
           case "left":
             return {
               ...t,
-              startDate: dayjs(t.startDate).add(totalMinutes, "minute").toISOString(),
+              startDate: commit(t.startDate),
             };
 
           case "right":
             return {
               ...t,
-              endDate: dayjs(t.endDate).add(totalMinutes, "minute").toISOString(),
+              endDate: commit(t.endDate),
             };
 
           default:

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -22,13 +22,13 @@ interface DragContext {
   initialBarWidth: number;
   dragSteps: number;
   basePxPerDragStep: number;
-  // 드래그 도중 스케일이 바뀌어도 시작 시점의 스텝 단위로 계산한다
+  // Keep computing in the step unit from when the drag started, even if the scale changes mid-drag
   scaleKey: GanttScaleKey;
   taskId: string;
 }
 
 /**
- * Gantt 바 드래그 기능을 제공하는 훅
+ * Hook providing the Gantt bar drag behavior
  */
 export function useGanttBarDrag(
   task: TaskTransformed,
@@ -43,8 +43,9 @@ export function useGanttBarDrag(
   const selectedScale = useGanttStore((s) => s.selectedScale);
   const { basePxPerDragStep } = GANTT_SCALE_CONFIG[selectedScale];
 
-  // 드래그 모드 감지
-  // 마일스톤과 좁은 바는 리사이즈 불가 - 엣지 영역이 바 전체를 덮어 이동이 막히는 것을 방지
+  // Detect the drag mode
+  // Milestones and narrow bars cannot be resized - keeps the edge zones from covering the
+  // whole bar and blocking the move
   const detectDragMode = (e: React.PointerEvent<HTMLDivElement>): DragMode => {
     if (isMilestoneTask(task)) return "bar";
 
@@ -59,9 +60,9 @@ export function useGanttBarDrag(
   };
 
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    // 주 포인터의 왼쪽 버튼만 드래그 시작 (우클릭/보조 터치는 무시)
+    // Only the primary pointer's left button starts a drag (right-click and secondary touches are ignored)
     if (!e.isPrimary || e.button !== 0) return;
-    // 이미 드래그 중이면 두 번째 포인터를 무시
+    // Ignore a second pointer while a drag is already running
     if (dragContextRef.current) return;
 
     const mode = detectDragMode(e);
@@ -90,8 +91,8 @@ export function useGanttBarDrag(
       const deltaX = moveEvent.clientX - ctx.initialClientX;
       const rawSteps = Math.round(deltaX / ctx.basePxPerDragStep);
 
-      // 최소 한 스텝 너비는 남기도록 스텝 자체를 클램프
-      // (미리보기만 막고 커밋은 그대로 두면 end < start 로 커밋된다)
+      // Clamp the step count itself so at least one step of width is left
+      // (clamping only the preview and leaving the commit alone commits end < start)
       const maxShrinkSteps = Math.floor(
         (ctx.initialBarWidth - ctx.basePxPerDragStep) / ctx.basePxPerDragStep
       );
@@ -159,7 +160,7 @@ export function useGanttBarDrag(
       storeApi.getState().clearDragOffset(taskId);
     };
 
-    // 브라우저가 제스처를 취소한 경우(스크롤 인계, 멀티터치 등)는 커밋하지 않고 되돌린다
+    // When the browser cancels the gesture (scroll takeover, multi-touch, etc.) revert instead of committing
     const handlePointerCancel = (cancelEvent: PointerEvent) => {
       const ctx = dragContextRef.current;
       if (ctx && cancelEvent.pointerId !== ctx.pointerId) return;
@@ -219,9 +220,9 @@ export function useGanttBarDrag(
       storeApi.getState().setRawTasks(updatedTasks);
       onTasksChangeRef.current?.(updatedTasks);
 
-      // dragOffset은 여기서 지우지 않는다 - 새 transformedTasks가 계산되기 전에
-      // 지우면 바가 한 프레임 동안 원위치로 돌아갔다 오는 깜빡임이 생긴다.
-      // Gantt의 타임라인 재계산 이펙트가 새 위치와 함께 한 번에 정리한다.
+      // dragOffset is deliberately not cleared here - clearing it before the new
+      // transformedTasks are computed makes the bar flick back to its old position for
+      // one frame. Gantt's timeline recomputation effect clears it along with the new positions.
       dragContextRef.current = null;
       dragModeRef.current = null;
       storeApi.getState().setCurrentTask(null);

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -4,7 +4,7 @@ import {
   MIN_RESIZABLE_WIDTH,
 } from "constants/gantt";
 import { useRef } from "react";
-import { useGanttStore } from "stores/store";
+import { useGanttStore, useGanttStoreApi } from "stores/context";
 import { GanttDragOffset } from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
@@ -41,6 +41,7 @@ export function useGanttBarDrag(
   task: TaskTransformed,
   onTasksChange?: (updatedTasks: Task[]) => void
 ) {
+  const storeApi = useGanttStoreApi();
   const dragContextRef = useRef<DragContext | null>(null);
   const dragModeRef = useRef<DragMode | null>(null);
   const onTasksChangeRef = useRef(onTasksChange);
@@ -88,7 +89,7 @@ export function useGanttBarDrag(
       taskId: task.id,
     };
 
-    useGanttStore.getState().setCurrentTask(task);
+    storeApi.getState().setCurrentTask(task);
     e.currentTarget.setPointerCapture(e.pointerId);
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
@@ -152,7 +153,7 @@ export function useGanttBarDrag(
         offsetEndDate: newEndDate,
       };
 
-      useGanttStore.getState().setDragOffset(ctx.taskId, offset);
+      storeApi.getState().setDragOffset(ctx.taskId, offset);
     };
 
     const detachListeners = () => {
@@ -164,8 +165,8 @@ export function useGanttBarDrag(
     const endDrag = (taskId: string) => {
       dragContextRef.current = null;
       dragModeRef.current = null;
-      useGanttStore.getState().setCurrentTask(null);
-      useGanttStore.getState().clearDragOffset(taskId);
+      storeApi.getState().setCurrentTask(null);
+      storeApi.getState().clearDragOffset(taskId);
     };
 
     // 브라우저가 제스처를 취소한 경우(스크롤 인계, 멀티터치 등)는 커밋하지 않고 되돌린다
@@ -193,7 +194,7 @@ export function useGanttBarDrag(
         return;
       }
 
-      const currentRawTasks = useGanttStore.getState().rawTasks;
+      const currentRawTasks = storeApi.getState().rawTasks;
       const minutesPerStep = ctx.dragStepAmount * TIME_UNIT_MULTIPLIERS[ctx.dragStepUnit as keyof typeof TIME_UNIT_MULTIPLIERS];
       const totalMinutes = ctx.dragSteps * minutesPerStep;
 
@@ -225,7 +226,7 @@ export function useGanttBarDrag(
         }
       });
 
-      useGanttStore.getState().setRawTasks(updatedTasks);
+      storeApi.getState().setRawTasks(updatedTasks);
       onTasksChangeRef.current?.(updatedTasks);
 
       // dragOffset은 여기서 지우지 않는다 - 새 transformedTasks가 계산되기 전에
@@ -233,7 +234,7 @@ export function useGanttBarDrag(
       // Gantt의 타임라인 재계산 이펙트가 새 위치와 함께 한 번에 정리한다.
       dragContextRef.current = null;
       dragModeRef.current = null;
-      useGanttStore.getState().setCurrentTask(null);
+      storeApi.getState().setCurrentTask(null);
     };
 
     document.addEventListener("pointermove", handlePointerMove);

--- a/src/hooks/useGanttProgressDrag.ts
+++ b/src/hooks/useGanttProgressDrag.ts
@@ -3,8 +3,8 @@ import { useGanttStoreApi } from "stores/context";
 import { normalizeProgress, Task, TaskTransformed } from "types/task";
 
 /**
- * 진행률 핸들 드래그 훅
- * 드래그 중에는 로컬 값으로 미리보기, pointerup 시 rawTasks에 커밋
+ * Progress handle drag hook
+ * Previews with a local value while dragging, commits to rawTasks on pointerup
  */
 export function useGanttProgressDrag(
   task: TaskTransformed,
@@ -27,7 +27,7 @@ export function useGanttProgressDrag(
   };
 
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
-    // 바 이동 드래그와 겹치지 않도록 차단
+    // Blocked so it does not overlap with the bar move drag
     e.stopPropagation();
     e.preventDefault();
 

--- a/src/hooks/useGanttProgressDrag.ts
+++ b/src/hooks/useGanttProgressDrag.ts
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { useGanttStore } from "stores/store";
+import { useGanttStoreApi } from "stores/context";
 import { normalizeProgress, Task, TaskTransformed } from "types/task";
 
 /**
@@ -11,6 +11,7 @@ export function useGanttProgressDrag(
   barRef: React.RefObject<HTMLDivElement | null>,
   onTasksChange?: (updatedTasks: Task[]) => void
 ) {
+  const storeApi = useGanttStoreApi();
   const [liveProgress, setLiveProgress] = useState<number | null>(null);
   const liveProgressRef = useRef<number | null>(null);
 
@@ -49,13 +50,13 @@ export function useGanttProgressDrag(
 
       if (percent === null) return;
 
-      const updatedTasks = useGanttStore
+      const updatedTasks = storeApi
         .getState()
         .rawTasks.map((t) =>
           t.id === task.id ? { ...t, progress: percent } : t
         );
 
-      useGanttStore.getState().setRawTasks(updatedTasks);
+      storeApi.getState().setRawTasks(updatedTasks);
       onTasksChange?.(updatedTasks);
     };
 

--- a/src/hooks/useGanttScrollApi.ts
+++ b/src/hooks/useGanttScrollApi.ts
@@ -5,23 +5,23 @@ import { TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
 import { calculateDateOffsetPx } from "utils/timeline";
 
-/** scrollToX 옵션 */
+/** Options for the scrollTo* methods */
 export interface GanttScrollOptions {
-  /** 부드럽게 이동할지 여부 (기본 true) */
+  /** Whether to animate the scroll (default true) */
   smooth?: boolean;
-  /** 뷰포트 안에서 대상이 놓일 위치 (기본 'center') */
+  /** Where the target lands inside the viewport (default 'center') */
   align?: "start" | "center";
 }
 
-/** ref로 노출되는 명령형 API */
+/** Imperative API exposed through the ref */
 export interface GanttHandle {
-  /** 특정 날짜로 가로 스크롤 */
+  /** Scroll horizontally to a given date */
   scrollToDate: (date: string | Date | Dayjs, options?: GanttScrollOptions) => void;
-  /** 오늘로 가로 스크롤 */
+  /** Scroll horizontally to today */
   scrollToToday: (options?: GanttScrollOptions) => void;
-  /** 특정 태스크로 가로/세로 스크롤 */
+  /** Scroll horizontally and vertically to a given task */
   scrollToTask: (taskId: string, options?: GanttScrollOptions) => void;
-  /** 스크롤 컨테이너 DOM 노드 (없으면 null) */
+  /** The scroll container DOM node (null when unavailable) */
   getScrollElement: () => HTMLDivElement | null;
 }
 
@@ -34,10 +34,10 @@ interface UseGanttScrollApiParams {
 }
 
 /**
- * 명령형 스크롤 API
+ * Imperative scroll API
  *
- * 타임라인 밖의 날짜나 없는 태스크 id는 조용히 무시한다 - 데이터 로딩 중
- * 호출하는 흔한 경우에 예외를 던지지 않기 위해서다.
+ * Dates outside the timeline and unknown task ids are ignored silently - so that
+ * the common case of calling while data is still loading does not throw.
  */
 export function useGanttScrollApi({
   scrollRef,
@@ -86,7 +86,7 @@ export function useGanttScrollApi({
       const el = scrollRef.current;
       if (!el) return;
 
-      // 세로: 해당 행이 뷰포트 밖일 때만 움직인다 (보이는 행을 굳이 재배치하지 않음)
+      // Vertical: move only when that row is outside the viewport (a visible row is left where it is)
       const rowTop = index * rowHeight;
       const outOfView =
         rowTop < el.scrollTop ||

--- a/src/hooks/useGanttSelectors.ts
+++ b/src/hooks/useGanttSelectors.ts
@@ -1,5 +1,5 @@
 import { useShallow } from "zustand/react/shallow";
-import { useGanttStore } from "stores/store";
+import { useGanttStore } from "stores/context";
 
 /**
  * Gantt 스토어에서 필요한 상태와 액션을 선택하는 훅

--- a/src/hooks/useGanttSelectors.ts
+++ b/src/hooks/useGanttSelectors.ts
@@ -2,29 +2,30 @@ import { useShallow } from "zustand/react/shallow";
 import { useGanttStore } from "stores/context";
 
 /**
- * Gantt 스토어에서 필요한 상태와 액션을 선택하는 훅
- * shallow 비교를 사용하여 불필요한 리렌더링 방지
+ * Hook selecting the state and actions needed from the Gantt store
+ * Uses shallow comparison to avoid unnecessary re-renders
  *
- * 드래그 프레임마다 바뀌는 dragOffsets/currentTask는 여기서 구독하지 않는다.
- * (필요한 컴포넌트에서 개별 구독 - 차트 전체가 매 프레임 리렌더되는 것을 방지)
+ * dragOffsets/currentTask change on every drag frame and are deliberately not
+ * subscribed to here. (Components that need them subscribe individually - this keeps
+ * the whole chart from re-rendering every frame)
  */
 export function useGanttSelectors() {
   return useGanttStore(
     useShallow((state) => ({
-      // 상태
+      // State
       rawTasks: state.rawTasks,
       transformedTasks: state.transformedTasks,
       bottomRowCells: state.bottomRowCells,
       selectedScale: state.selectedScale,
 
-      // 액션
+      // Actions
       setRawTasks: state.setRawTasks,
       setTransformedTasks: state.setTransformedTasks,
       setBottomRowCells: state.setBottomRowCells,
       setSelectedScale: state.setSelectedScale,
       clearAllDragOffsets: state.clearAllDragOffsets,
 
-      // 계산된 값
+      // Computed values
       getTotalWidth: state.getTotalWidth,
     }))
   );

--- a/src/hooks/useGanttVirtualization.ts
+++ b/src/hooks/useGanttVirtualization.ts
@@ -25,17 +25,19 @@ interface UseGanttVirtualizationResult
 }
 
 /**
- * 열(column) 가상화
+ * Column virtualization
  *
- * 헤더의 하단 시간 셀 렌더와 가로 가시성 판정을 같은 창(window)으로 맞추기 위해
- * 따로 떼어 두었다 - 헤더와 바가 서로 다른 기준으로 잘리면 안 된다.
+ * Split out so that rendering the header's bottom time cells and judging horizontal
+ * visibility use the same window - the header and the bars must not be culled by
+ * different criteria.
  */
 export function useGanttColumnVirtualization({
   bottomRowCells,
   scrollRef,
 }: UseGanttColumnVirtualizationParams): UseGanttColumnVirtualizationResult {
-  // TanStack Virtual이 돌려주는 함수는 메모이즈할 수 없어 React Compiler가
-  // 이 훅을 건너뛴다 - 아래 행 가상화에 같은 경고가 이미 남아 있어 중복만 끈다
+  // The functions TanStack Virtual returns cannot be memoized, so the React Compiler
+  // skips this hook - the row virtualization below already carries the same warning,
+  // so this only silences the duplicate
   // eslint-disable-next-line react-hooks/incompatible-library
   const columnVirtualizer = useVirtualizer({
     horizontal: true,
@@ -45,7 +47,7 @@ export function useGanttColumnVirtualization({
     overscan: 5,
   });
 
-  // 가시 영역 계산
+  // Compute the visible area
   const virtualItems = columnVirtualizer.getVirtualItems();
   const visibleStartPx = virtualItems[0]?.start ?? 0;
   const lastVirtualItem = virtualItems[virtualItems.length - 1];
@@ -53,7 +55,7 @@ export function useGanttColumnVirtualization({
     ? lastVirtualItem.start + lastVirtualItem.size
     : 0;
 
-  // 바 가시성 체크 함수
+  // Bar visibility check
   const isBarVisible = useMemo(() => {
     return (barLeft: number, barWidth: number): boolean => {
       const barRight = barLeft + barWidth;
@@ -61,7 +63,7 @@ export function useGanttColumnVirtualization({
     };
   }, [visibleStartPx, visibleEndPx]);
 
-  // 셀 변경 시 열 가상화 측정 업데이트
+  // Update the column virtualizer's measurements when the cells change
   useEffect(() => {
     if (!bottomRowCells.length) return;
 
@@ -79,15 +81,15 @@ export function useGanttColumnVirtualization({
 }
 
 /**
- * Gantt 차트의 가상화 로직을 관리하는 훅
- * 행(row)과 열(column) 가상화를 설정하고 가시성 체크 함수 제공
+ * Hook managing the Gantt chart's virtualization
+ * Sets up row and column virtualization and provides the visibility check
  */
 export function useGanttVirtualization({
   transformedTasks,
   bottomRowCells,
   scrollRef,
 }: UseGanttVirtualizationParams): UseGanttVirtualizationResult {
-  // 행 가상화 설정
+  // Row virtualization setup
   const rowVirtualizer = useVirtualizer({
     count: transformedTasks.length,
     getScrollElement: () => scrollRef.current,

--- a/src/hooks/useGanttVirtualization.ts
+++ b/src/hooks/useGanttVirtualization.ts
@@ -4,36 +4,39 @@ import { RefObject, useEffect, useMemo } from "react";
 import { GanttBottomRowCell } from "types/gantt";
 import { TaskTransformed } from "types/task";
 
-interface UseGanttVirtualizationParams {
-  transformedTasks: TaskTransformed[];
+interface UseGanttColumnVirtualizationParams {
   bottomRowCells: GanttBottomRowCell[];
   scrollRef: RefObject<HTMLDivElement | null>;
 }
 
-interface UseGanttVirtualizationResult {
-  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+interface UseGanttColumnVirtualizationResult {
   columnVirtualizer: Virtualizer<HTMLDivElement, Element>;
   isBarVisible: (barLeft: number, barWidth: number) => boolean;
 }
 
+interface UseGanttVirtualizationParams
+  extends UseGanttColumnVirtualizationParams {
+  transformedTasks: TaskTransformed[];
+}
+
+interface UseGanttVirtualizationResult
+  extends UseGanttColumnVirtualizationResult {
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+}
+
 /**
- * Gantt 차트의 가상화 로직을 관리하는 훅
- * 행(row)과 열(column) 가상화를 설정하고 가시성 체크 함수 제공
+ * 열(column) 가상화
+ *
+ * 헤더의 하단 시간 셀 렌더와 가로 가시성 판정을 같은 창(window)으로 맞추기 위해
+ * 따로 떼어 두었다 - 헤더와 바가 서로 다른 기준으로 잘리면 안 된다.
  */
-export function useGanttVirtualization({
-  transformedTasks,
+export function useGanttColumnVirtualization({
   bottomRowCells,
   scrollRef,
-}: UseGanttVirtualizationParams): UseGanttVirtualizationResult {
-  // 행 가상화 설정
-  const rowVirtualizer = useVirtualizer({
-    count: transformedTasks.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => NODE_HEIGHT,
-    overscan: 5,
-  });
-
-  // 열 가상화 설정
+}: UseGanttColumnVirtualizationParams): UseGanttColumnVirtualizationResult {
+  // TanStack Virtual이 돌려주는 함수는 메모이즈할 수 없어 React Compiler가
+  // 이 훅을 건너뛴다 - 아래 행 가상화에 같은 경고가 이미 남아 있어 중복만 끈다
+  // eslint-disable-next-line react-hooks/incompatible-library
   const columnVirtualizer = useVirtualizer({
     horizontal: true,
     count: bottomRowCells.length,
@@ -70,8 +73,32 @@ export function useGanttVirtualization({
   }, [bottomRowCells, columnVirtualizer]);
 
   return {
-    rowVirtualizer,
     columnVirtualizer,
     isBarVisible,
+  };
+}
+
+/**
+ * Gantt 차트의 가상화 로직을 관리하는 훅
+ * 행(row)과 열(column) 가상화를 설정하고 가시성 체크 함수 제공
+ */
+export function useGanttVirtualization({
+  transformedTasks,
+  bottomRowCells,
+  scrollRef,
+}: UseGanttVirtualizationParams): UseGanttVirtualizationResult {
+  // 행 가상화 설정
+  const rowVirtualizer = useVirtualizer({
+    count: transformedTasks.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => NODE_HEIGHT,
+    overscan: 5,
+  });
+
+  const column = useGanttColumnVirtualization({ bottomRowCells, scrollRef });
+
+  return {
+    rowVirtualizer,
+    ...column,
   };
 }

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -24,35 +24,36 @@ const getSystemTheme = (): 'light' | 'dark' | null => {
   return window.matchMedia(SYSTEM_DARK_QUERY).matches ? 'dark' : 'light';
 };
 
-// 서버 렌더와 하이드레이션 첫 렌더에서는 시스템 설정을 알 수 없다
+// The system setting is unknowable during server rendering and the first hydration render
 const getServerSystemTheme = (): 'light' | 'dark' | null => null;
 
 /**
- * 테마를 해결하고 관련 클래스명과 data 속성을 생성하는 훅
+ * Hook that resolves the theme and builds the matching class name and data attribute
  *
- * 'system' 테마는 useSyncExternalStore로 구독한다 - 서버 렌더와 하이드레이션
- * 첫 렌더에서는 null(테마 클래스 없음)을 쓰고 하이드레이션 이후에 실제 시스템
- * 설정으로 전환하므로, 하이드레이션 불일치나 잘못된 테마로 고착되는 일이 없다.
+ * The 'system' theme is subscribed to with useSyncExternalStore - server rendering and
+ * the first hydration render use null (no theme class) and switch to the real system
+ * setting after hydration, so there is no hydration mismatch and no getting stuck on
+ * the wrong theme.
  */
 export function useResolvedTheme(
   theme?: GanttTheme,
   baseClassName = 'gantt-container'
 ): UseResolvedThemeResult {
-  // 시스템 테마 (prefers-color-scheme 구독)
+  // System theme (subscribes to prefers-color-scheme)
   const systemTheme = useSyncExternalStore(
     subscribeSystemTheme,
     getSystemTheme,
     getServerSystemTheme
   );
 
-  // 최종 테마 결정 - theme이 없으면 호스트가 테마를 관리하므로 아무것도 붙이지 않고,
-  // 'system'은 해석되기 전까지 null
+  // Resolve the final theme - with no theme prop the host manages theming, so nothing is
+  // attached; 'system' stays null until it resolves
   const resolvedTheme = useMemo((): 'light' | 'dark' | null => {
     if (!theme) return null;
     return theme === 'system' ? systemTheme : theme;
   }, [theme, systemTheme]);
 
-  // 컨테이너 클래스명 생성
+  // Build the container class name
   const containerClassName = useMemo(
     () => (resolvedTheme ? `${baseClassName} ${resolvedTheme}` : baseClassName),
     [baseClassName, resolvedTheme]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
-// 스타일
+// Styles
 import './assets/styles/gantt.css';
 
-// 메인 컴포넌트
+// Main component
 export { default as ReactGanttChart } from './pages/Gantt';
 
-// 타입 내보내기
+// Type exports
 export type { GanttProps } from './pages/Gantt';
 export type {
   GanttHandle,

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -3,12 +3,17 @@ import GanttChartHeader from "components/GanttChartHeader";
 import GanttDependencyArrows from "components/GanttDependencyArrows";
 import GanttDragGuides from "components/GanttDragGuides";
 import ScaleSelector from "components/ScaleSelector";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Dayjs } from "dayjs";
 import { useGanttSelectors } from "hooks/useGanttSelectors";
 import { useGanttVirtualization } from "hooks/useGanttVirtualization";
 import { useResolvedTheme } from "hooks/useResolvedTheme";
-import { readPersistedScale } from "stores/store";
+import { GanttStoreContext } from "stores/context";
+import {
+  createGanttStore,
+  DEFAULT_SCALE_STORAGE_KEY,
+  readPersistedScale,
+} from "stores/store";
 import { GanttScaleKey, GanttTheme } from "types/gantt";
 import { Task } from "types/task";
 import dayjs from "utils/dayjs";
@@ -58,13 +63,37 @@ export interface GanttProps {
   holidays?: string[];
   /** 비근무일 판별 커스텀 함수 - 지정 시 기본 주말/휴일 판별을 대체 */
   isNonWorkingDay?: (date: Dayjs) => boolean;
+  /**
+   * 스케일 선택을 저장할 sessionStorage 키 (기본 `"gantt-scale"`)
+   *
+   * 한 페이지에 차트를 두 개 이상 두면 서로 다른 키를 주어야 각자의 스케일을
+   * 따로 기억한다. 같은 키를 공유하면 마지막에 바꾼 값이 양쪽에 적용된다.
+   */
+  storageKey?: string;
 }
 
 /**
- * Gantt 차트 메인 컴포넌트
+ * Gantt 차트 컴포넌트
+ *
+ * 인스턴스마다 독립된 스토어를 만들어 컨텍스트로 내려준다.
+ * (모듈 싱글턴이면 한 페이지의 두 차트가 상태를 공유해 서로를 덮어쓴다)
+ */
+function Gantt(props: GanttProps) {
+  const storageKey = props.storageKey ?? DEFAULT_SCALE_STORAGE_KEY;
+  const [store] = useState(() => createGanttStore(storageKey));
+
+  return (
+    <GanttStoreContext.Provider value={store}>
+      <GanttChart {...props} />
+    </GanttStoreContext.Provider>
+  );
+}
+
+/**
+ * 실제 차트 렌더링
  * 가상화를 사용하여 대량의 태스크를 효율적으로 렌더링
  */
-function Gantt({
+function GanttChart({
   tasks = EMPTY_TASKS,
   onTasksChange,
   height = DEFAULT_HEIGHT,
@@ -75,6 +104,7 @@ function Gantt({
   showNonWorkingDays = true,
   holidays,
   isNonWorkingDay,
+  storageKey = DEFAULT_SCALE_STORAGE_KEY,
 }: GanttProps) {
   // 스토어 상태 및 액션
   const {
@@ -109,7 +139,7 @@ function Gantt({
   // 초기 스케일 설정 - 세션에 저장된 사용자 선택이 있으면 그 값이 defaultScale보다 우선
   // (마운트 시 1회만. defaultScale은 시드일 뿐이라 이후 변경은 무시한다)
   useEffect(() => {
-    setSelectedScale(readPersistedScale() ?? defaultScale);
+    setSelectedScale(readPersistedScale(storageKey) ?? defaultScale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -34,67 +34,71 @@ import {
   originShiftPx,
 } from "utils/timeline";
 
-/** Gantt 컴포넌트 기본값 */
+/** Gantt component defaults */
 const DEFAULT_HEIGHT = 600;
 const DEFAULT_WIDTH = "100%";
 const DEFAULT_SCALE: GanttScaleKey = "month";
-/** 기본 tasks - 매 렌더 새 배열이 생기지 않도록 모듈 스코프에 고정 */
+/** Default tasks - kept at module scope so a new array is not created on every render */
 const EMPTY_TASKS: Task[] = [];
 
 export interface GanttProps {
   /**
-   * 태스크 데이터 배열
+   * Task data array
    *
-   * 내용이 실제로 바뀔 때만 차트에 반영된다. 부모가 같은 데이터를 새 배열로
-   * 다시 넘기는 경우(인라인 리터럴, 비메모 map 등)에는 무시되므로 드래그로
-   * 방금 편집한 결과가 되돌아가지 않는다. 빈 배열을 넘기면 차트가 비워진다.
+   * Only reflected in the chart when the contents actually change. When the
+   * parent passes the same data as a new array (an inline literal, a
+   * non-memoized map, and so on) the update is ignored, so an edit you just
+   * made by dragging is not reverted. Passing an empty array clears the chart.
    */
   tasks?: Task[];
-  /** 태스크 변경 시 호출되는 콜백 */
+  /** Callback invoked when tasks change */
   onTasksChange?: (updatedTasks: Task[]) => void;
-  /** 차트 높이 (px 또는 CSS 값) */
+  /** Chart height (px or a CSS value) */
   height?: number | string;
-  /** 차트 너비 (px 또는 CSS 값) */
+  /** Chart width (px or a CSS value) */
   width?: number | string;
-  /** 테마 설정 - 'light', 'dark', 또는 'system' */
+  /** Theme setting - 'light', 'dark', or 'system' */
   theme?: GanttTheme;
   /**
-   * 초기 스케일 설정
+   * Initial scale
    *
-   * 세션에 저장된 사용자 선택(sessionStorage)이 없을 때만 적용되는 시드 값이다.
-   * 사용자가 스케일을 바꾸면 그 선택이 저장되어 리마운트 시 우선하며,
-   * 마운트 이후의 prop 변경은 무시된다 (`default*` prop 관례).
+   * A seed value that only applies when the session has no user selection
+   * stored (sessionStorage). Once the user changes the scale, that choice is
+   * saved and wins on remount, and prop changes after mount are ignored
+   * (the usual `default*` prop convention).
    */
   defaultScale?: GanttScaleKey;
-  /** 추가 CSS 클래스명 */
+  /** Additional CSS class name */
   className?: string;
-  /** 주말/휴일 음영 표시 여부 (기본 true) */
+  /** Whether to shade weekends/holidays (default true) */
   showNonWorkingDays?: boolean;
-  /** 휴일 목록 (ISO 날짜 문자열, 예: '2026-01-01') */
+  /** Holiday list (ISO date strings, e.g. '2026-01-01') */
   holidays?: string[];
-  /** 비근무일 판별 커스텀 함수 - 지정 시 기본 주말/휴일 판별을 대체 */
+  /** Custom non-working-day predicate - replaces the default weekend/holiday check when given */
   isNonWorkingDay?: (date: Dayjs) => boolean;
   /**
-   * 스케일 선택을 저장할 sessionStorage 키 (기본 `"gantt-scale"`)
+   * sessionStorage key the scale selection is stored under (default `"gantt-scale"`)
    *
-   * 한 페이지에 차트를 두 개 이상 두면 서로 다른 키를 주어야 각자의 스케일을
-   * 따로 기억한다. 같은 키를 공유하면 마지막에 바꾼 값이 양쪽에 적용된다.
+   * With more than one chart on a page, give them different keys so each
+   * remembers its own scale. Sharing one key means the last change made
+   * applies to both.
    */
   storageKey?: string;
   /**
-   * 첫 렌더 후 한 번 스크롤할 위치
+   * Position to scroll to once, after the first render
    *
-   * `"today"`는 오늘로, 날짜 문자열은 그 날짜로 이동한다. 이후의 데이터
-   * 갱신은 스크롤 위치를 건드리지 않는다.
+   * `"today"` moves to today, a date string to that date. Later data updates
+   * do not touch the scroll position.
    */
   initialScrollTo?: "today" | string;
 }
 
 /**
- * Gantt 차트 컴포넌트
+ * Gantt chart component
  *
- * 인스턴스마다 독립된 스토어를 만들어 컨텍스트로 내려준다.
- * (모듈 싱글턴이면 한 페이지의 두 차트가 상태를 공유해 서로를 덮어쓴다)
+ * Creates a store per instance and hands it down through context.
+ * (With a module singleton, two charts on one page would share state and
+ * overwrite each other)
  */
 const Gantt = forwardRef<GanttHandle, GanttProps>(function Gantt(props, ref) {
   const storageKey = props.storageKey ?? DEFAULT_SCALE_STORAGE_KEY;
@@ -108,8 +112,8 @@ const Gantt = forwardRef<GanttHandle, GanttProps>(function Gantt(props, ref) {
 });
 
 /**
- * 실제 차트 렌더링
- * 가상화를 사용하여 대량의 태스크를 효율적으로 렌더링
+ * Renders the actual chart
+ * Uses virtualization to render large numbers of tasks efficiently
  */
 function GanttChart({
   tasks = EMPTY_TASKS,
@@ -126,7 +130,7 @@ function GanttChart({
   initialScrollTo,
   forwardedRef,
 }: GanttProps & { forwardedRef: React.ForwardedRef<GanttHandle> }) {
-  // 스토어 상태 및 액션
+  // Store state and actions
   const {
     rawTasks,
     transformedTasks,
@@ -140,38 +144,39 @@ function GanttChart({
     getTotalWidth,
   } = useGanttSelectors();
 
-  // 스크롤 컨테이너 ref
+  // Scroll container ref
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // 가상화 훅
+  // Virtualization hook
   const { rowVirtualizer, isBarVisible } = useGanttVirtualization({
     transformedTasks,
     bottomRowCells,
     scrollRef,
   });
 
-  // 테마 훅
+  // Theme hook
   const { containerClassName, dataTheme } = useResolvedTheme(
     theme,
     className ? `gantt-container ${className}` : "gantt-container"
   );
 
-  // 초기 스케일 설정 - 세션에 저장된 사용자 선택이 있으면 그 값이 defaultScale보다 우선
-  // (마운트 시 1회만. defaultScale은 시드일 뿐이라 이후 변경은 무시한다)
+  // Initial scale - a user selection saved in the session wins over defaultScale
+  // (once, on mount. defaultScale is only a seed, so later changes are ignored)
   useEffect(() => {
     setSelectedScale(readPersistedScale(storageKey) ?? defaultScale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 프롭으로 받아 마지막으로 반영한 태스크 데이터의 스냅샷
+  // Snapshot of the task data last applied from props
   const syncedTasksRef = useRef<string | null>(null);
 
-  // 태스크 데이터 동기화
-  // 배열 identity가 아니라 내용이 바뀌었을 때만 스토어를 덮어쓴다.
-  // 부모가 같은 데이터를 새 배열로 다시 넘기는 리렌더는 무시되므로 드래그 편집이
-  // 되돌아가지 않고, 데이터가 실제로 달라지면(빈 배열 포함) 프롭이 이긴다.
-  // (비교는 직렬화 1회 - tasks 배열 identity가 바뀔 때만 돈다. 태스크 수가
-  //  아주 많아 이 비용이 문제가 되면 부모에서 tasks를 memo 하면 된다)
+  // Sync the task data
+  // Overwrite the store only when the contents changed, not when the array identity did.
+  // A re-render where the parent passes the same data as a new array is ignored, so drag
+  // edits are not reverted; when the data really differs (an empty array included) the
+  // prop wins.
+  // (The comparison is one serialization - it only runs when the tasks array identity
+  //  changes. If there are so many tasks that this cost matters, memoize tasks in the parent)
   useEffect(() => {
     const snapshot = JSON.stringify(tasks);
     if (snapshot === syncedTasksRef.current) return;
@@ -180,21 +185,22 @@ function GanttChart({
     setRawTasks(tasks);
   }, [tasks, setRawTasks]);
 
-  // 직전 타임라인의 셀 - 원점 이동량을 계산해 스크롤을 보정하는 데 쓴다
+  // Cells of the previous timeline - used to compute how far the origin moved and compensate the scroll
   const prevCellsRef = useRef<GanttBottomRowCell[]>([]);
   const pendingScrollShiftRef = useRef(0);
 
-  // 타임라인 구조 설정 (태스크가 비면 빈 타임라인으로 정리)
+  // Build the timeline structure (clears to an empty timeline when there are no tasks)
   useLayoutEffect(() => {
     const { bottomCells, transformedTasks: transformed } = computeTimelineData(
       rawTasks,
       selectedScale
     );
 
-    // 타임라인 시작일이 바뀌면 모든 바가 통째로 밀린다.
-    // (가장 이른 태스크를 드래그하면 min(startDate)가 바뀌어 원점이 이동한다)
-    // 여기서는 보정량만 기록한다 - 콘텐츠가 넓어지기 전에 scrollLeft를 올리면
-    // 브라우저가 그 시점의 최대값으로 잘라버리기 때문에 실제 적용은 아래에서.
+    // When the timeline start date changes, every bar shifts as a whole.
+    // (Dragging the earliest task changes min(startDate), which moves the origin)
+    // Only the compensation amount is recorded here - raising scrollLeft before the
+    // content gets wider makes the browser clamp it to the maximum at that moment,
+    // so the actual adjustment happens below.
     const prevCells = prevCellsRef.current;
     if (prevCells.length && bottomCells.length) {
       pendingScrollShiftRef.current += originShiftPx(
@@ -207,7 +213,7 @@ function GanttChart({
 
     setBottomRowCells(bottomCells);
     setTransformedTasks(transformed);
-    // 새 위치가 준비된 시점에 드래그 오프셋 정리 - 드롭 시 한 프레임 깜빡임 방지
+    // Clear the drag offsets now that the new positions are ready - avoids a one-frame flicker on drop
     clearAllDragOffsets();
   }, [
     rawTasks,
@@ -217,7 +223,7 @@ function GanttChart({
     clearAllDragOffsets,
   ]);
 
-  // 새 타임라인 너비가 DOM에 반영된 뒤에 스크롤 보정을 적용한다
+  // Apply the scroll compensation after the new timeline width has landed in the DOM
   useLayoutEffect(() => {
     const shift = pendingScrollShiftRef.current;
     if (!shift) return;
@@ -227,17 +233,17 @@ function GanttChart({
     if (scrollEl) scrollEl.scrollLeft += shift;
   }, [bottomRowCells]);
 
-  // 스케일 변경 핸들러
+  // Scale change handler
   const handleScaleChange = (scale: GanttScaleKey) => {
     setSelectedScale(scale);
   };
 
-  // 오늘 마커 오프셋 (타임라인 범위 밖이면 null)
+  // Today marker offset (null when today is outside the timeline range)
   const todayOffsetPx = useMemo(
     () => calculateDateOffsetPx(dayjs(), bottomRowCells, selectedScale),
     [bottomRowCells, selectedScale]
   );
-  // 비근무일 음영 범위 계산
+  // Compute the non-working-day shading ranges
   const nonWorkingRanges = useMemo(() => {
     if (!showNonWorkingDays) return [];
 
@@ -262,7 +268,7 @@ function GanttChart({
     selectedScale,
   ]);
 
-  // 명령형 스크롤 API
+  // Imperative scroll API
   const scrollApi = useGanttScrollApi({
     scrollRef,
     bottomRowCells,
@@ -272,7 +278,7 @@ function GanttChart({
   });
   useImperativeHandle(forwardedRef, () => scrollApi, [scrollApi]);
 
-  // initialScrollTo는 타임라인이 처음 준비됐을 때 한 번만 적용한다
+  // initialScrollTo is applied once, when the timeline first becomes ready
   const didInitialScrollRef = useRef(false);
   useEffect(() => {
     if (didInitialScrollRef.current || !initialScrollTo) return;
@@ -283,10 +289,10 @@ function GanttChart({
     scrollApi.scrollToDate(target, { smooth: false });
   }, [initialScrollTo, bottomRowCells, scrollApi]);
 
-  // 전체 너비 계산
+  // Total width
   const totalWidth = getTotalWidth();
 
-  // 스타일 계산
+  // Computed styles
   const containerStyle = {
     height: typeof height === "number" ? `${height}px` : height,
     width: typeof width === "number" ? `${width}px` : width,
@@ -298,7 +304,7 @@ function GanttChart({
       data-theme={dataTheme}
       style={containerStyle}
     >
-      {/* 툴바 */}
+      {/* Toolbar */}
       <div className="gantt-toolbar">
         <ScaleSelector
           selectedScale={selectedScale}
@@ -306,13 +312,13 @@ function GanttChart({
         />
       </div>
 
-      {/* 메인 차트 영역 */}
+      {/* Main chart area */}
       <div className="gantt-main">
         <div ref={scrollRef} className="gantt-scroll-container">
-          {/* 드래그 가이드 (헤더 포함 전체 관통) */}
+          {/* Drag guides (run through everything, header included) */}
           <GanttDragGuides width={totalWidth} />
 
-          {/* 헤더 */}
+          {/* Header */}
           <div className="gantt-header-wrapper" style={{ width: `${totalWidth}px` }}>
             <GanttChartHeader
               bottomRowCells={bottomRowCells}
@@ -322,7 +328,7 @@ function GanttChart({
             />
           </div>
 
-          {/* 콘텐츠 영역 */}
+          {/* Content area */}
           <div
             className="gantt-content"
             style={{
@@ -330,7 +336,7 @@ function GanttChart({
               width: `${totalWidth}px`,
             }}
           >
-            {/* 비근무일 음영 */}
+            {/* Non-working-day shading */}
             {nonWorkingRanges.length > 0 && (
               <div className="gantt-non-working-layer" aria-hidden="true">
                 {nonWorkingRanges.map((range) => (
@@ -346,7 +352,7 @@ function GanttChart({
               </div>
             )}
 
-            {/* 태스크 행 (배경) */}
+            {/* Task rows (background) */}
             <div className="gantt-rows">
               {rowVirtualizer.getVirtualItems().map((virtualRow) => {
                 const task = transformedTasks[virtualRow.index];
@@ -355,7 +361,7 @@ function GanttChart({
                     key={`row-${task.id}`}
                     className="gantt-task-row"
                     style={{
-                      // border-box라 1px 보더가 높이 안에 포함된다 - 행 간격과 정확히 일치
+                      // border-box, so the 1px border is inside the height - matches the row spacing exactly
                       height: `${virtualRow.size}px`,
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
@@ -364,7 +370,7 @@ function GanttChart({
               })}
             </div>
 
-            {/* 오늘 마커 */}
+            {/* Today marker */}
             {todayOffsetPx !== null && (
               <div
                 className="gantt-today-marker"
@@ -373,10 +379,10 @@ function GanttChart({
               />
             )}
 
-            {/* 의존성 화살표 */}
+            {/* Dependency arrows */}
             <GanttDependencyArrows transformedTasks={transformedTasks} />
 
-            {/* 태스크 바 */}
+            {/* Task bars */}
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
               const task = transformedTasks[virtualRow.index];
               const barLeft = task.barLeft ?? 0;

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext } from "react";
+import { useStore } from "zustand";
+import { GanttState, GanttStoreApi } from "./store";
+
+/** 인스턴스별 스토어를 하위 컴포넌트에 전달 */
+export const GanttStoreContext = createContext<GanttStoreApi | null>(null);
+
+function useStoreApi(): GanttStoreApi {
+  const store = useContext(GanttStoreContext);
+  if (!store) {
+    throw new Error(
+      "Gantt store is missing. Render this component inside <ReactGanttChart>."
+    );
+  }
+  return store;
+}
+
+/** 이 인스턴스의 스토어를 구독한다 */
+export function useGanttStore<T>(selector: (state: GanttState) => T): T {
+  return useStore(useStoreApi(), selector);
+}
+
+/**
+ * 구독 없이 스토어 API만 가져온다 (이벤트 핸들러 안에서 getState/setState 용)
+ * 렌더 중 값을 읽는 데 쓰면 안 된다 - 그때는 useGanttStore를 쓴다.
+ */
+export function useGanttStoreApi(): GanttStoreApi {
+  return useStoreApi();
+}

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -2,7 +2,7 @@ import { createContext, useContext } from "react";
 import { useStore } from "zustand";
 import { GanttState, GanttStoreApi } from "./store";
 
-/** 인스턴스별 스토어를 하위 컴포넌트에 전달 */
+/** Passes the per-instance store down to child components */
 export const GanttStoreContext = createContext<GanttStoreApi | null>(null);
 
 function useStoreApi(): GanttStoreApi {
@@ -15,14 +15,14 @@ function useStoreApi(): GanttStoreApi {
   return store;
 }
 
-/** 이 인스턴스의 스토어를 구독한다 */
+/** Subscribes to this instance's store */
 export function useGanttStore<T>(selector: (state: GanttState) => T): T {
   return useStore(useStoreApi(), selector);
 }
 
 /**
- * 구독 없이 스토어 API만 가져온다 (이벤트 핸들러 안에서 getState/setState 용)
- * 렌더 중 값을 읽는 데 쓰면 안 된다 - 그때는 useGanttStore를 쓴다.
+ * Returns the store API without subscribing (for getState/setState inside event handlers)
+ * Must not be used to read values during render - use useGanttStore for that.
  */
 export function useGanttStoreApi(): GanttStoreApi {
   return useStoreApi();

--- a/src/stores/store.test.ts
+++ b/src/stores/store.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import dayjs from 'utils/dayjs';
 // 이 import 자체가 SSR 안전성 회귀 테스트다 - 모듈 스코프에서 sessionStorage를
 // 건드리면 노드 환경(jsdom 없음)에서 파일 로드가 곧바로 실패한다.
-import { readPersistedScale, useGanttStore } from './store';
+import { createGanttStore, readPersistedScale } from './store';
 
 // 노드 환경에는 sessionStorage가 없으므로 최소 스텁을 심고 쓰기 횟수를 센다
 const writes: Array<[string, string]> = [];
@@ -23,18 +23,11 @@ const stubSessionStorage = () => {
   return data;
 };
 
-const initialState = useGanttStore.getState();
+// 인스턴스마다 새 스토어 - 테스트끼리 상태를 공유하지 않는다
+let store: ReturnType<typeof createGanttStore>;
 
 beforeEach(() => {
-  useGanttStore.setState({
-    ...initialState,
-    rawTasks: [],
-    transformedTasks: [],
-    bottomRowCells: [],
-    selectedScale: 'month',
-    currentTask: null,
-    dragOffsets: {},
-  });
+  store = createGanttStore();
 });
 
 describe('readPersistedScale', () => {
@@ -63,10 +56,10 @@ describe('setSelectedScale persistence', () => {
   it('writes the scale once and skips a redundant write', () => {
     stubSessionStorage();
 
-    useGanttStore.getState().setSelectedScale('week');
-    useGanttStore.getState().setSelectedScale('week');
+    store.getState().setSelectedScale('week');
+    store.getState().setSelectedScale('week');
 
-    expect(useGanttStore.getState().selectedScale).toBe('week');
+    expect(store.getState().selectedScale).toBe('week');
     expect(writes).toEqual([['gantt-scale', 'week']]);
     expect(readPersistedScale()).toBe('week');
   });
@@ -75,15 +68,15 @@ describe('setSelectedScale persistence', () => {
     stubSessionStorage();
 
     for (let i = 0; i < 50; i++) {
-      useGanttStore.getState().setDragOffset('t1', {
+      store.getState().setDragOffset('t1', {
         offsetX: i,
         offsetWidth: 0,
         offsetStartDate: dayjs('2025-01-01'),
         offsetEndDate: dayjs('2025-01-02'),
       });
     }
-    useGanttStore.getState().clearAllDragOffsets();
-    useGanttStore.getState().setRawTasks([]);
+    store.getState().clearAllDragOffsets();
+    store.getState().setRawTasks([]);
 
     expect(writes).toEqual([]);
   });
@@ -91,14 +84,14 @@ describe('setSelectedScale persistence', () => {
   it('survives an unavailable sessionStorage', () => {
     Reflect.deleteProperty(globalThis, 'sessionStorage');
 
-    expect(() => useGanttStore.getState().setSelectedScale('day')).not.toThrow();
-    expect(useGanttStore.getState().selectedScale).toBe('day');
+    expect(() => store.getState().setSelectedScale('day')).not.toThrow();
+    expect(store.getState().selectedScale).toBe('day');
   });
 });
 
 describe('setRawTasks', () => {
   it('accepts an empty array so the chart can be cleared', () => {
-    useGanttStore.setState({
+    store.setState({
       rawTasks: [
         {
           id: 'a',
@@ -111,8 +104,44 @@ describe('setRawTasks', () => {
       ],
     });
 
-    useGanttStore.getState().setRawTasks([]);
+    store.getState().setRawTasks([]);
 
-    expect(useGanttStore.getState().rawTasks).toEqual([]);
+    expect(store.getState().rawTasks).toEqual([]);
+  });
+});
+
+describe('per-instance isolation', () => {
+  it('keeps two charts on one page from sharing state', () => {
+    stubSessionStorage();
+
+    const a = createGanttStore('gantt-scale-a');
+    const b = createGanttStore('gantt-scale-b');
+
+    a.getState().setSelectedScale('week');
+    a.getState().setRawTasks([
+      {
+        id: 'a1',
+        name: 'a1',
+        startDate: '2025-01-01',
+        endDate: '2025-01-02',
+        parentId: null,
+        sequence: '1',
+      },
+    ]);
+    a.getState().setDragOffset('a1', {
+      offsetX: 12,
+      offsetWidth: 0,
+      offsetStartDate: dayjs('2025-01-01'),
+      offsetEndDate: dayjs('2025-01-02'),
+    });
+
+    expect(b.getState().selectedScale).toBe('month');
+    expect(b.getState().rawTasks).toEqual([]);
+    expect(b.getState().dragOffsets).toEqual({});
+
+    // 스케일 저장도 인스턴스별 키로 분리된다
+    b.getState().setSelectedScale('day');
+    expect(readPersistedScale('gantt-scale-a')).toBe('week');
+    expect(readPersistedScale('gantt-scale-b')).toBe('day');
   });
 });

--- a/src/stores/store.test.ts
+++ b/src/stores/store.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import dayjs from 'utils/dayjs';
-// 이 import 자체가 SSR 안전성 회귀 테스트다 - 모듈 스코프에서 sessionStorage를
-// 건드리면 노드 환경(jsdom 없음)에서 파일 로드가 곧바로 실패한다.
+// This import is itself the SSR-safety regression test - touching sessionStorage at
+// module scope would make loading the file fail outright in a Node environment (no jsdom).
 import { createGanttStore, readPersistedScale } from './store';
 
-// 노드 환경에는 sessionStorage가 없으므로 최소 스텁을 심고 쓰기 횟수를 센다
+// Node has no sessionStorage, so a minimal stub is installed and the writes are counted
 const writes: Array<[string, string]> = [];
 const stubSessionStorage = () => {
   const data = new Map<string, string>();
@@ -23,7 +23,7 @@ const stubSessionStorage = () => {
   return data;
 };
 
-// 인스턴스마다 새 스토어 - 테스트끼리 상태를 공유하지 않는다
+// A fresh store per instance - tests do not share state
 let store: ReturnType<typeof createGanttStore>;
 
 beforeEach(() => {
@@ -139,7 +139,7 @@ describe('per-instance isolation', () => {
     expect(b.getState().rawTasks).toEqual([]);
     expect(b.getState().dragOffsets).toEqual({});
 
-    // 스케일 저장도 인스턴스별 키로 분리된다
+    // Scale persistence is separated by the per-instance key too
     b.getState().setSelectedScale('day');
     expect(readPersistedScale('gantt-scale-a')).toBe('week');
     expect(readPersistedScale('gantt-scale-b')).toBe('day');

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -7,15 +7,16 @@ import {
 import { Task, TaskTransformed } from "types/task";
 import { createStore } from "zustand";
 
-/** 스케일 선택을 세션에 보존하는 기본 키 */
+/** Default key the scale selection is persisted under for the session */
 export const DEFAULT_SCALE_STORAGE_KEY = "gantt-scale";
 
 /**
- * 세션에 저장된 스케일을 읽는다 - 저장값이 없거나 세션 저장소에 접근할 수 없으면 null
+ * Reads the scale saved for the session - null when nothing is stored or session
+ * storage cannot be reached
  *
- * 모듈 로드 시점이 아니라 마운트 이후에만 호출해야 한다.
- * (SSR에서 import만으로 sessionStorage를 건드리지 않게, 그리고 첫 렌더를
- *  서버와 동일하게 유지해 하이드레이션 불일치를 만들지 않게)
+ * Must be called only after mount, never at module load time.
+ * (So a bare import does not touch sessionStorage under SSR, and so the first render
+ *  matches the server's and creates no hydration mismatch)
  */
 export function readPersistedScale(
   storageKey: string = DEFAULT_SCALE_STORAGE_KEY
@@ -26,7 +27,7 @@ export function readPersistedScale(
       ? (stored as GanttScaleKey)
       : null;
   } catch {
-    // SSR/프라이빗 모드 등 세션 저장소를 쓸 수 없는 환경
+    // Environments where session storage is unusable - SSR, private mode, and so on
     return null;
   }
 }
@@ -39,7 +40,7 @@ export interface GanttState {
   dragOffsets: Record<string, GanttDragOffset>;
   transformedTasks: TaskTransformed[];
 
-  // 액션
+  // Actions
   setSelectedScale: (scale: GanttScaleKey) => void;
   setCurrentTask: (task: TaskTransformed | null) => void;
   setRawTasks: (rawTasks: Task[]) => void;
@@ -49,7 +50,7 @@ export interface GanttState {
   clearDragOffset: (id: string) => void;
   clearAllDragOffsets: () => void;
 
-  // 계산된 셀렉터
+  // Computed selectors
   getCurrentDragOffset: (taskId: string) => GanttDragOffset | null;
   getTotalWidth: () => number;
 }
@@ -57,10 +58,10 @@ export interface GanttState {
 export type GanttStoreApi = ReturnType<typeof createGanttStore>;
 
 /**
- * Gantt 인스턴스 하나당 스토어 하나를 만든다.
+ * Creates one store per Gantt instance.
  *
- * 모듈 스코프 싱글턴이면 한 페이지의 두 차트가 태스크/스케일/드래그 상태를
- * 공유해 서로를 덮어쓴다.
+ * With a module-scope singleton, two charts on one page would share task, scale
+ * and drag state and overwrite each other.
  */
 export function createGanttStore(
   storageKey: string = DEFAULT_SCALE_STORAGE_KEY
@@ -75,15 +76,15 @@ export function createGanttStore(
 
     setCurrentTask: (task) => set({ currentTask: task }),
 
-    // 세션 저장은 여기서만 - persist 미들웨어를 쓰면 드래그 프레임마다 스토어가
-    // 갱신될 때도 sessionStorage에 동기 쓰기가 발생한다
+    // Session persistence happens only here - with the persist middleware, every store
+    // update would write to sessionStorage synchronously, drag frames included
     setSelectedScale: (scale) => {
       if (get().selectedScale === scale) return;
       set({ selectedScale: scale });
       try {
         sessionStorage.setItem(storageKey, scale);
       } catch {
-        // 세션 저장소를 쓸 수 없는 환경 - 저장만 건너뛴다
+        // Session storage is unusable - only the persisting is skipped
       }
     },
 
@@ -102,8 +103,8 @@ export function createGanttStore(
         return { dragOffsets: rest };
       }),
 
-    // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
-    // 타임라인 재계산에 휩쓸려 사라지지 않도록
+    // Keep the offset of a drag that is still in progress - so a drag started right
+    // after a drop is not swept away by the timeline recomputation
     clearAllDragOffsets: () =>
       set((state) => {
         const activeId = state.currentTask?.id;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -5,10 +5,10 @@ import {
   GanttScaleKey,
 } from "types/gantt";
 import { Task, TaskTransformed } from "types/task";
-import { create } from "zustand";
+import { createStore } from "zustand";
 
-/** 스케일 선택을 세션에 보존하는 키 */
-const SCALE_STORAGE_KEY = "gantt-scale";
+/** 스케일 선택을 세션에 보존하는 기본 키 */
+export const DEFAULT_SCALE_STORAGE_KEY = "gantt-scale";
 
 /**
  * 세션에 저장된 스케일을 읽는다 - 저장값이 없거나 세션 저장소에 접근할 수 없으면 null
@@ -17,9 +17,11 @@ const SCALE_STORAGE_KEY = "gantt-scale";
  * (SSR에서 import만으로 sessionStorage를 건드리지 않게, 그리고 첫 렌더를
  *  서버와 동일하게 유지해 하이드레이션 불일치를 만들지 않게)
  */
-export function readPersistedScale(): GanttScaleKey | null {
+export function readPersistedScale(
+  storageKey: string = DEFAULT_SCALE_STORAGE_KEY
+): GanttScaleKey | null {
   try {
-    const stored = sessionStorage.getItem(SCALE_STORAGE_KEY);
+    const stored = sessionStorage.getItem(storageKey);
     return stored && stored in GANTT_SCALE_CONFIG
       ? (stored as GanttScaleKey)
       : null;
@@ -29,7 +31,7 @@ export function readPersistedScale(): GanttScaleKey | null {
   }
 }
 
-interface GanttState {
+export interface GanttState {
   rawTasks: Task[];
   bottomRowCells: GanttBottomRowCell[];
   selectedScale: GanttScaleKey;
@@ -52,64 +54,76 @@ interface GanttState {
   getTotalWidth: () => number;
 }
 
-export const useGanttStore = create<GanttState>()((set, get) => ({
-  rawTasks: [],
-  transformedTasks: [],
-  bottomRowCells: [],
-  selectedScale: "month",
-  currentTask: null,
-  dragOffsets: {},
+export type GanttStoreApi = ReturnType<typeof createGanttStore>;
 
-  setCurrentTask: (task) => set({ currentTask: task }),
+/**
+ * Gantt 인스턴스 하나당 스토어 하나를 만든다.
+ *
+ * 모듈 스코프 싱글턴이면 한 페이지의 두 차트가 태스크/스케일/드래그 상태를
+ * 공유해 서로를 덮어쓴다.
+ */
+export function createGanttStore(
+  storageKey: string = DEFAULT_SCALE_STORAGE_KEY
+) {
+  return createStore<GanttState>()((set, get) => ({
+    rawTasks: [],
+    transformedTasks: [],
+    bottomRowCells: [],
+    selectedScale: "month",
+    currentTask: null,
+    dragOffsets: {},
 
-  // 세션 저장은 여기서만 - persist 미들웨어를 쓰면 드래그 프레임마다 스토어가
-  // 갱신될 때도 sessionStorage에 동기 쓰기가 발생한다
-  setSelectedScale: (scale) => {
-    if (get().selectedScale === scale) return;
-    set({ selectedScale: scale });
-    try {
-      sessionStorage.setItem(SCALE_STORAGE_KEY, scale);
-    } catch {
-      // 세션 저장소를 쓸 수 없는 환경 - 저장만 건너뛴다
-    }
-  },
+    setCurrentTask: (task) => set({ currentTask: task }),
 
-  setRawTasks: (raw) => set({ rawTasks: raw }),
-  setBottomRowCells: (cells) => set({ bottomRowCells: cells }),
-  setTransformedTasks: (tasks) => set({ transformedTasks: tasks }),
-
-  setDragOffset: (id, offset) =>
-    set((state) => ({
-      dragOffsets: { ...state.dragOffsets, [id]: offset },
-    })),
-
-  clearDragOffset: (id) =>
-    set((state) => {
-      const { [id]: _removed, ...rest } = state.dragOffsets;
-      return { dragOffsets: rest };
-    }),
-
-  // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
-  // 타임라인 재계산에 휩쓸려 사라지지 않도록
-  clearAllDragOffsets: () =>
-    set((state) => {
-      const activeId = state.currentTask?.id;
-      const keys = Object.keys(state.dragOffsets);
-      if (!keys.length) return state;
-      if (!activeId || !state.dragOffsets[activeId]) {
-        return { dragOffsets: {} };
+    // 세션 저장은 여기서만 - persist 미들웨어를 쓰면 드래그 프레임마다 스토어가
+    // 갱신될 때도 sessionStorage에 동기 쓰기가 발생한다
+    setSelectedScale: (scale) => {
+      if (get().selectedScale === scale) return;
+      set({ selectedScale: scale });
+      try {
+        sessionStorage.setItem(storageKey, scale);
+      } catch {
+        // 세션 저장소를 쓸 수 없는 환경 - 저장만 건너뛴다
       }
-      if (keys.length === 1) return state;
-      return { dragOffsets: { [activeId]: state.dragOffsets[activeId] } };
-    }),
+    },
 
-  getCurrentDragOffset: (taskId: string) => {
-    const state = get();
-    return state.dragOffsets[taskId] || null;
-  },
+    setRawTasks: (raw) => set({ rawTasks: raw }),
+    setBottomRowCells: (cells) => set({ bottomRowCells: cells }),
+    setTransformedTasks: (tasks) => set({ transformedTasks: tasks }),
 
-  getTotalWidth: () => {
-    const state = get();
-    return state.bottomRowCells.reduce((sum, cell) => sum + cell.widthPx, 0);
-  },
-}));
+    setDragOffset: (id, offset) =>
+      set((state) => ({
+        dragOffsets: { ...state.dragOffsets, [id]: offset },
+      })),
+
+    clearDragOffset: (id) =>
+      set((state) => {
+        const { [id]: _removed, ...rest } = state.dragOffsets;
+        return { dragOffsets: rest };
+      }),
+
+    // 진행 중인 드래그의 오프셋은 남긴다 - 드롭 직후 곧바로 시작된 드래그가
+    // 타임라인 재계산에 휩쓸려 사라지지 않도록
+    clearAllDragOffsets: () =>
+      set((state) => {
+        const activeId = state.currentTask?.id;
+        const keys = Object.keys(state.dragOffsets);
+        if (!keys.length) return state;
+        if (!activeId || !state.dragOffsets[activeId]) {
+          return { dragOffsets: {} };
+        }
+        if (keys.length === 1) return state;
+        return { dragOffsets: { [activeId]: state.dragOffsets[activeId] } };
+      }),
+
+    getCurrentDragOffset: (taskId: string) => {
+      const state = get();
+      return state.dragOffsets[taskId] || null;
+    },
+
+    getTotalWidth: () => {
+      const state = get();
+      return state.bottomRowCells.reduce((sum, cell) => sum + cell.widthPx, 0);
+    },
+  }));
+}

--- a/src/types/gantt.ts
+++ b/src/types/gantt.ts
@@ -1,6 +1,6 @@
 import { Dayjs } from 'dayjs';
 
-/** 테마 타입 - 'light', 'dark', 또는 'system' (시스템 설정 따름) */
+/** Theme type - 'light', 'dark', or 'system' (follows the OS setting) */
 export type GanttTheme = 'light' | 'dark' | 'system';
 
 export type GanttScaleKey = 'day' | 'week' | 'month' | 'year';

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -7,9 +7,9 @@ export interface Task {
   endDate: string;
   parentId: string | null;
   sequence: string;
-  /** 태스크 종류 - 'milestone'은 startDate 기준 다이아몬드로 렌더링 (기본 'task') */
+  /** Task kind - 'milestone' renders as a diamond at startDate (default 'task') */
   type?: TaskType;
-  /** 진행률 0-100 (%) - 생략 시 진행률 표시 없음 */
+  /** Progress 0-100 (%) - omitted means no progress display */
   progress?: number;
   dependencies?: TaskDependency[];
 }
@@ -18,7 +18,7 @@ export function isMilestoneTask(task: Pick<Task, 'type'>): boolean {
   return task.type === 'milestone';
 }
 
-/** 진행률을 0-100 범위로 정규화, 값이 없거나 유효하지 않으면 null */
+/** Normalizes progress into the 0-100 range; null when the value is missing or invalid */
 export function normalizeProgress(progress: number | undefined): number | null {
   if (typeof progress !== 'number' || Number.isNaN(progress)) return null;
   return Math.min(100, Math.max(0, progress));

--- a/src/utils/arrowPath.ts
+++ b/src/utils/arrowPath.ts
@@ -5,7 +5,7 @@ import {
   TaskTransformed,
 } from "types/task";
 
-/** 드래그 중인 태스크의 라이브 오프셋 (드래그 중이 아니면 0) */
+/** Live offset of the task being dragged (0 when it is not being dragged) */
 export interface DragOffset {
   offsetX: number;
   offsetWidth: number;
@@ -301,9 +301,9 @@ export function getSmartGanttPath(
 }
 
 /**
- * 태스크 양 끝의 화살표 앵커 X 좌표.
- * 드래그 중이면 해당 태스크의 라이브 오프셋을 반영하고,
- * 마일스톤은 다이아몬드 좌/우 꼭짓점에 연결한다.
+ * Arrow anchor X coordinates at both ends of a task.
+ * Applies that task's live offset while it is being dragged, and connects
+ * milestones at the left/right vertices of the diamond.
  */
 function anchorX(task: TaskTransformed, offset: DragOffset) {
   const half = isMilestoneTask(task) ? MILESTONE_HALF_DIAGONAL : 0;
@@ -315,13 +315,13 @@ function anchorX(task: TaskTransformed, offset: DragOffset) {
   };
 }
 
-/** 개발 모드에서 타입별로 한 번만 경고 */
+/** Warn once per type, in development mode */
 const warnedDepTypes = new Set<string>();
 
 /**
- * 의존성 하나의 화살표 좌표 계산.
- * targetTask가 선행(predecessor), sourceTask가 의존성을 소유한 후행(successor).
- * 알 수 없는 의존성 타입이면 null (해당 화살표만 건너뜀).
+ * Computes the arrow coordinates for a single dependency.
+ * targetTask is the predecessor, sourceTask the successor that owns the dependency.
+ * Returns null for an unknown dependency type (only that arrow is skipped).
  */
 export function calculateArrowCoords(
   sourceTask: TaskTransformed,
@@ -334,20 +334,20 @@ export function calculateArrowCoords(
   const sourceIndex = sourceTask.order - 1;
   const targetIndex = targetTask.order - 1;
 
-  // 바 중앙 높이에서 연결 (전통적인 Gantt 차트 스타일)
+  // Connect at the vertical center of the bar (classic Gantt chart style)
   const barCenterY = rowHeight / 2;
   const fromY = targetIndex * rowHeight + barCenterY;
   const toY = sourceIndex * rowHeight + barCenterY;
 
-  // 양쪽 끝 모두 자기 자신의 드래그 오프셋을 반영해야 화살표가 바를 따라온다
+  // Both ends have to apply their own drag offset for the arrow to follow the bars
   const from = anchorX(targetTask, targetOffset);
   const to = anchorX(sourceTask, sourceOffset);
 
-  // 의존성 타입에 따른 X 좌표 설정
-  // FS: 선행 태스크 우측 → 후행 태스크 좌측
-  // SS: 선행 태스크 좌측 → 후행 태스크 좌측
-  // FF: 선행 태스크 우측 → 후행 태스크 우측
-  // SF: 선행 태스크 좌측 → 후행 태스크 우측
+  // X coordinates per dependency type
+  // FS: predecessor right → successor left
+  // SS: predecessor left → successor left
+  // FF: predecessor right → successor right
+  // SF: predecessor left → successor right
   const coordinateMap = {
     FS: [from.endX, to.startX] as const,
     SS: [from.startX, to.startX] as const,
@@ -355,7 +355,7 @@ export function calculateArrowCoords(
     SF: [from.startX, to.endX] as const,
   };
 
-  // 태스크는 consumer가 넘기는 JSON이라 런타임에 알 수 없는 타입이 올 수 있다
+  // Tasks come from consumer-supplied JSON, so an unknown type can arrive at runtime
   const coords: readonly [number, number] | undefined =
     coordinateMap[depType as keyof typeof coordinateMap];
 
@@ -375,10 +375,11 @@ export function calculateArrowCoords(
 }
 
 /**
- * id로 태스크를 찾기 위한 인덱스.
+ * Index for looking up tasks by id.
  *
- * 태스크 배열이 바뀔 때 한 번만 만들어 재사용한다 - 의존성마다 배열을 훑으면
- * 태스크 수의 제곱에 비례하는 비용이 드래그 프레임마다 다시 발생한다.
+ * Built once whenever the task array changes and then reused - scanning the array
+ * for every dependency costs time proportional to the square of the task count,
+ * and that cost would be paid again on every drag frame.
  */
 export function buildTaskIndex(
   transformedTasks: TaskTransformed[]
@@ -386,23 +387,24 @@ export function buildTaskIndex(
   return new Map(transformedTasks.map((task) => [task.id, task]));
 }
 
-/** 화살표 하나가 뷰포트를 벗어나는지 판정할 때 두는 여유 (px) */
+/** Slack allowed when deciding whether a single arrow falls outside the viewport (px) */
 const ARROW_BLEED = 32;
 
-/** 화살표 컬링용 가시 영역 */
+/** Visible area used for arrow culling */
 export interface ArrowViewport {
-  /** 세로 가시 범위 (행 가상화 기준, px) */
+  /** Vertical visible range (in row-virtualization terms, px) */
   topPx: number;
   bottomPx: number;
-  /** 가로 가시성 - 열 가상화의 바 가시성 판정을 그대로 쓴다 */
+  /** Horizontal visibility - reuses the column virtualization's bar visibility check */
   isBarVisible: (left: number, width: number) => boolean;
 }
 
 /**
- * 화살표가 가시 영역과 겹치는지 판정.
+ * Decides whether an arrow overlaps the visible area.
  *
- * 양 끝 좌표의 바운딩 박스로 보므로 양쪽 끝이 모두 화면 밖이어도 선이 화면을
- * 가로지르면 그린다. 꺾인 경로가 끝점보다 조금 바깥으로 나가므로 여유를 둔다.
+ * It looks at the bounding box of the two endpoints, so a line is still drawn when
+ * both ends are off-screen but it crosses the viewport. The elbowed path runs a
+ * little past the endpoints, hence the slack.
  */
 export function isArrowVisible(
   dep: Pick<RenderedDependency, "fromX" | "fromY" | "toX" | "toY">,
@@ -418,8 +420,9 @@ export function isArrowVisible(
 }
 
 /**
- * 의존성 배열 빌드.
- * 인덱스를 순회 대상 겸 조회용으로 쓴다 (삽입 순서 = 태스크 순서).
+ * Builds the dependency array.
+ * The index doubles as the iteration source and the lookup table
+ * (insertion order = task order).
  */
 export function buildDependencies(
   taskById: Map<string, TaskTransformed>,

--- a/src/utils/arrowPath.ts
+++ b/src/utils/arrowPath.ts
@@ -374,18 +374,64 @@ export function calculateArrowCoords(
   return { fromX, fromY, toX, toY };
 }
 
-/** 의존성 배열 빌드 */
+/**
+ * id로 태스크를 찾기 위한 인덱스.
+ *
+ * 태스크 배열이 바뀔 때 한 번만 만들어 재사용한다 - 의존성마다 배열을 훑으면
+ * 태스크 수의 제곱에 비례하는 비용이 드래그 프레임마다 다시 발생한다.
+ */
+export function buildTaskIndex(
+  transformedTasks: TaskTransformed[]
+): Map<string, TaskTransformed> {
+  return new Map(transformedTasks.map((task) => [task.id, task]));
+}
+
+/** 화살표 하나가 뷰포트를 벗어나는지 판정할 때 두는 여유 (px) */
+const ARROW_BLEED = 32;
+
+/** 화살표 컬링용 가시 영역 */
+export interface ArrowViewport {
+  /** 세로 가시 범위 (행 가상화 기준, px) */
+  topPx: number;
+  bottomPx: number;
+  /** 가로 가시성 - 열 가상화의 바 가시성 판정을 그대로 쓴다 */
+  isBarVisible: (left: number, width: number) => boolean;
+}
+
+/**
+ * 화살표가 가시 영역과 겹치는지 판정.
+ *
+ * 양 끝 좌표의 바운딩 박스로 보므로 양쪽 끝이 모두 화면 밖이어도 선이 화면을
+ * 가로지르면 그린다. 꺾인 경로가 끝점보다 조금 바깥으로 나가므로 여유를 둔다.
+ */
+export function isArrowVisible(
+  dep: Pick<RenderedDependency, "fromX" | "fromY" | "toX" | "toY">,
+  viewport: ArrowViewport
+): boolean {
+  const top = Math.min(dep.fromY, dep.toY) - ARROW_BLEED;
+  const bottom = Math.max(dep.fromY, dep.toY) + ARROW_BLEED;
+  if (bottom < viewport.topPx || top > viewport.bottomPx) return false;
+
+  const left = Math.min(dep.fromX, dep.toX) - ARROW_BLEED;
+  const right = Math.max(dep.fromX, dep.toX) + ARROW_BLEED;
+  return viewport.isBarVisible(left, right - left);
+}
+
+/**
+ * 의존성 배열 빌드.
+ * 인덱스를 순회 대상 겸 조회용으로 쓴다 (삽입 순서 = 태스크 순서).
+ */
 export function buildDependencies(
-  transformedTasks: TaskTransformed[],
+  taskById: Map<string, TaskTransformed>,
   liveOffsets: Record<string, DragOffset>
 ): RenderedDependency[] {
   const dependencies: RenderedDependency[] = [];
 
-  for (const currentTask of transformedTasks) {
+  for (const currentTask of taskById.values()) {
     const sourceOffset = liveOffsets[currentTask.id] ?? NO_OFFSET;
 
     for (const dep of currentTask.dependencies ?? []) {
-      const targetTask = transformedTasks.find((t) => t.id === dep.targetId);
+      const targetTask = taskById.get(dep.targetId);
       if (!targetTask) continue;
 
       const coords = calculateArrowCoords(

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,20 +1,21 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
-// 플러그인은 실제로 쓰는 것만 등록한다.
-// (이전에는 12개를 등록했지만 호출부가 하나도 없어 번들만 키웠다)
+// Only the plugins actually used are registered.
+// (12 used to be registered with no caller at all - they only grew the bundle)
 dayjs.extend(utc);
 
 /**
- * 차트 전용 dayjs - 항상 UTC 모드로 파싱하고 표시한다.
+ * The chart's own dayjs - always parses and displays in UTC mode.
  *
- * 태스크 날짜의 계약이 "UTC ISO 문자열"이므로(README > Task Format) 배치와 라벨도
- * UTC에 맞춘다. 로컬 모드로 파싱하면 같은 데이터가 뷰어의 위치에 따라 다른 날짜
- * 칸에 그려지고(#84), 로컬 달력의 DST 날(23/25시간) 때문에 셀 너비도 흔들린다(#28).
+ * The contract for task dates is "UTC ISO string" (README > Task Format), so
+ * positioning and labels follow UTC too. Parsing in local mode would draw the same
+ * data in different date cells depending on where the viewer is (#84), and local
+ * calendar DST days (23/25 hours) would make cell widths wobble as well (#28).
  *
- * - 존이 붙은 문자열('...Z', '+09:00')은 그 순간을 UTC 시각으로 표시한다
- * - 존이 없는 문자열('2025-06-01', '2025-06-01T09:00')은 UTC 벽시계로 읽으므로
- *   뷰어 타임존과 무관하게 적은 그대로 표시된다
+ * - A string carrying a zone ('...Z', '+09:00') displays that instant as a UTC time
+ * - A string without a zone ('2025-06-01', '2025-06-01T09:00') is read as a UTC wall
+ *   clock, so it displays exactly as written, whatever the viewer's time zone
  */
 const ganttDayjs = dayjs.utc;
 

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,6 +1,21 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 
 // 플러그인은 실제로 쓰는 것만 등록한다.
 // (이전에는 12개를 등록했지만 호출부가 하나도 없어 번들만 키웠다)
+dayjs.extend(utc);
 
-export default dayjs;
+/**
+ * 차트 전용 dayjs - 항상 UTC 모드로 파싱하고 표시한다.
+ *
+ * 태스크 날짜의 계약이 "UTC ISO 문자열"이므로(README > Task Format) 배치와 라벨도
+ * UTC에 맞춘다. 로컬 모드로 파싱하면 같은 데이터가 뷰어의 위치에 따라 다른 날짜
+ * 칸에 그려지고(#84), 로컬 달력의 DST 날(23/25시간) 때문에 셀 너비도 흔들린다(#28).
+ *
+ * - 존이 붙은 문자열('...Z', '+09:00')은 그 순간을 UTC 시각으로 표시한다
+ * - 존이 없는 문자열('2025-06-01', '2025-06-01T09:00')은 UTC 벽시계로 읽으므로
+ *   뷰어 타임존과 무관하게 적은 그대로 표시된다
+ */
+const ganttDayjs = dayjs.utc;
+
+export default ganttDayjs;

--- a/src/utils/headerUtils.ts
+++ b/src/utils/headerUtils.ts
@@ -1,8 +1,8 @@
 import { GanttTopHeaderGroup } from 'types/gantt';
 
 /**
- * 동일한 라벨을 가진 연속된 그룹들을 병합
- * 같은 월/년도 등의 연속된 셀들을 하나의 그룹으로 합침
+ * Merges consecutive groups that carry the same label
+ * Consecutive cells in the same month/year and so on become a single group
  */
 export function mergeHeaderGroups(
   groups: GanttTopHeaderGroup[]
@@ -12,10 +12,10 @@ export function mergeHeaderGroups(
   for (const group of groups) {
     const last = merged[merged.length - 1];
     if (last && last.label === group.label) {
-      // 기존 그룹에 너비 추가
+      // Add the width to the existing group
       last.widthPx += group.widthPx;
     } else {
-      // 새 그룹 시작
+      // Start a new group
       merged.push({ ...group });
     }
   }

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -51,6 +51,22 @@ export function computeNonWorkingRanges(
   return ranges;
 }
 
+/**
+ * 드래그 스텝 수만큼 날짜를 옮긴다
+ *
+ * 스케일의 드래그 단위(hour/day)를 그대로 더한다. 분으로 환산해서 더하면
+ * (day = 1440분) 로컬 달력의 DST 경계에서 하루가 23/25시간이라 한 시간씩
+ * 어긋나고, 자정 근처 태스크는 아예 다른 날짜 칸에 커밋된다.
+ */
+export function shiftByDragSteps(
+  date: Dayjs,
+  steps: number,
+  scaleKey: GanttScaleKey
+): Dayjs {
+  const { dragStepUnit, dragStepAmount } = GANTT_SCALE_CONFIG[scaleKey];
+  return date.add(steps * dragStepAmount, dragStepUnit);
+}
+
 export function calculateDateOffsets(
   startDate: Dayjs,
   endDate: Dayjs,

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -20,13 +20,14 @@ export interface NonWorkingRange {
 }
 
 /**
- * 타임라인 원점이 이동한 만큼의 px - scrollLeft 보정값
+ * How far the timeline origin moved, in px - the scrollLeft compensation
  *
- * 타임라인 범위는 태스크의 min/max 날짜에서 나오므로, 가장 이른 태스크를
- * 드래그하면 원점이 통째로 움직이고 모든 바가 화면에서 밀린다.
- * 이 값을 scrollLeft에 더하면 보이던 날짜가 제자리에 남는다.
+ * The timeline range comes from the tasks' min/max dates, so dragging the
+ * earliest task moves the origin as a whole and pushes every bar across the
+ * screen. Adding this value to scrollLeft keeps the date you were looking at
+ * in place.
  *
- * 앞에 셀이 늘어났으면 양수, 줄어들었으면 음수를 반환한다.
+ * Positive when cells were added in front, negative when they were removed.
  */
 export function originShiftPx(
   prevTicks: GanttBottomRowCell[],
@@ -40,16 +41,16 @@ export function originShiftPx(
   const diff = prevOrigin.valueOf() - nextOrigin.valueOf();
   if (diff === 0) return 0;
 
-  // 이전 원점이 더 늦다 = 앞쪽에 셀이 추가됨 (새 타임라인에서 이전 원점의 위치만큼 이동)
+  // The previous origin is later = cells were added in front (shift by where the previous origin sits in the new timeline)
   if (diff > 0) return calculateDateOffsetPx(prevOrigin, nextTicks, scaleKey) ?? 0;
 
-  // 이전 원점이 더 이르다 = 앞쪽 셀이 사라짐
+  // The previous origin is earlier = leading cells disappeared
   return -(calculateDateOffsetPx(nextOrigin, prevTicks, scaleKey) ?? 0);
 }
 
 /**
- * 비근무일(주말/휴일) 셀을 px 범위로 병합해 반환
- * 틱 단위가 하루 이하인 스케일에서만 적용
+ * Merges non-working (weekend/holiday) cells into px ranges
+ * Only applies to scales whose tick unit is a day or finer
  */
 export function computeNonWorkingRanges(
   timelineTicks: GanttBottomRowCell[],
@@ -80,11 +81,12 @@ export function computeNonWorkingRanges(
 }
 
 /**
- * 드래그 스텝 수만큼 날짜를 옮긴다
+ * Moves a date by the given number of drag steps
  *
- * 스케일의 드래그 단위(hour/day)를 그대로 더한다. 분으로 환산해서 더하면
- * (day = 1440분) 로컬 달력의 DST 경계에서 하루가 23/25시간이라 한 시간씩
- * 어긋나고, 자정 근처 태스크는 아예 다른 날짜 칸에 커밋된다.
+ * Adds the scale's drag unit (hour/day) as-is. Converting to minutes first
+ * (day = 1440 minutes) drifts by an hour at a local-calendar DST boundary,
+ * where a day is 23 or 25 hours, and tasks near midnight get committed to an
+ * entirely different date cell.
  */
 export function shiftByDragSteps(
   date: Dayjs,
@@ -123,18 +125,18 @@ export function calculateDateOffsets(
     const tickStartTime = tickStart.valueOf();
     const tickEndTime = tickEnd.valueOf();
 
-    // 태스크 시작 전 틱은 스킵
+    // Skip ticks that fall before the task starts
     if (tickEndTime <= startTime) {
       leftMargin += tickWidth;
       continue;
     }
 
-    // 태스크 종료 후면 중단
+    // Stop once past the task's end
     if (tickStartTime >= endTime) {
       break;
     }
 
-    // 겹치는 영역 계산
+    // Compute the overlapping region
     const overlapStart = startTime > tickStartTime ? startDate : tickStart;
     const overlapEnd = endTime < tickEndTime ? endDate : tickEnd;
 
@@ -142,7 +144,7 @@ export function calculateDateOffsets(
     const overlapDuration = overlapEnd.valueOf() - overlapStart.valueOf();
     const overlapRatio = overlapDuration / tickDuration;
 
-    // 첫 번째 겹치는 틱의 부분 너비 추가
+    // Add the partial width of the first overlapping tick
     if (!hasStarted && overlapStart.valueOf() > tickStartTime) {
       const beforeStartRatio =
         (overlapStart.valueOf() - tickStartTime) / tickDuration;
@@ -160,8 +162,8 @@ export function calculateDateOffsets(
 }
 
 /**
- * 특정 날짜의 타임라인 px 오프셋 계산
- * 타임라인 범위 밖이면 null 반환
+ * Computes the px offset of a given date along the timeline
+ * Returns null when the date is outside the timeline range
  */
 export function calculateDateOffsetPx(
   date: Dayjs,
@@ -260,8 +262,8 @@ function createBottomRowCells(
 }
 
 /**
- * 하단 셀을 기반으로 상단 헤더 그룹 생성
- * 헤더 컴포넌트에서 사용
+ * Builds the top header groups from the bottom cells
+ * Used by the header component
  */
 export function createTopHeaderGroups(
   bottomCells: GanttBottomRowCell[],
@@ -302,8 +304,8 @@ export function createTopHeaderGroups(
 }
 
 /**
- * 타임라인 데이터 계산
- * rawTasks와 scale을 기반으로 bottomCells와 transformedTasks 반환
+ * Computes the timeline data
+ * Returns bottomCells and transformedTasks for the given rawTasks and scale
  */
 export function computeTimelineData(
   rawTasks: Task[],
@@ -313,7 +315,7 @@ export function computeTimelineData(
     return { bottomCells: [], transformedTasks: [] };
   }
 
-  // 날짜 범위 찾기 및 패딩 추가
+  // Find the date range and add padding
   const { minDate, maxDate } = findDateRangeFromTasks(rawTasks);
   const { paddedMinDate, paddedMaxDate } = padDateRange(
     minDate,
@@ -321,7 +323,7 @@ export function computeTimelineData(
     selectedScale
   );
 
-  // 타임라인 컴포넌트 생성
+  // Build the timeline pieces
   const bottomCells = createBottomRowCells(
     paddedMinDate,
     paddedMaxDate,

--- a/src/utils/timezone.test.ts
+++ b/src/utils/timezone.test.ts
@@ -6,8 +6,8 @@ import dayjs from 'utils/dayjs';
 import { computeTimelineData, shiftByDragSteps } from './timeline';
 
 /**
- * 테스트 동안만 뷰어의 로컬 타임존을 바꾼다.
- * (Node는 process.env.TZ 대입 즉시 Date 계산에 반영한다)
+ * Switches the viewer's local time zone for the duration of the test only.
+ * (Node applies an assignment to process.env.TZ to Date math immediately)
  */
 function withTimeZone<T>(tz: string, fn: () => T): T {
   const prev = process.env.TZ;
@@ -32,30 +32,30 @@ const task = (startDate: string, endDate: string): Task => ({
 const widths = (t: Task, scale: 'day' | 'week' | 'month' | 'year') =>
   computeTimelineData([t], scale).bottomCells.map((c) => c.widthPx);
 
-// America/New_York: 2025-03-09 는 23시간(봄 DST), 2025-11-02 는 25시간(가을 DST)
+// America/New_York: 2025-03-09 is 23 hours (spring DST), 2025-11-02 is 25 hours (fall DST)
 const SPRING_FORWARD = task('2025-03-08T00:00:00Z', '2025-03-10T00:00:00Z');
 const FALL_BACK = task('2025-11-01T00:00:00Z', '2025-11-03T00:00:00Z');
 
-describe('DST 경계에서의 타임라인 셀 (#28)', () => {
-  it('봄 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
-    // 예전: 23시간짜리 하루가 diff('day') 정수 절삭으로 0일이 되어 3/9 셀이 0px로 사라졌다
+describe('timeline cells across DST boundaries (#28)', () => {
+  it('keeps day cell widths uniform through a spring DST week', () => {
+    // Before: a 23-hour day truncated to 0 days by diff('day'), so the 3/9 cell vanished at 0px
     withTimeZone('America/New_York', () => {
       expect(new Set(widths(SPRING_FORWARD, 'month'))).toEqual(new Set([32]));
       expect(new Set(widths(SPRING_FORWARD, 'week'))).toEqual(new Set([216]));
     });
   });
 
-  it('가을 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
-    // 예전: 25시간짜리 하루가 week 스케일에서 225px(다른 날은 216px)로 튀었다
+  it('keeps day cell widths uniform through a fall DST week', () => {
+    // Before: a 25-hour day jumped to 225px at week scale, where every other day was 216px
     withTimeZone('America/New_York', () => {
       expect(new Set(widths(FALL_BACK, 'month'))).toEqual(new Set([32]));
       expect(new Set(widths(FALL_BACK, 'week'))).toEqual(new Set([216]));
     });
   });
 
-  it('year 스케일 월 셀 너비가 실제 달력 월 길이를 따른다', () => {
-    // year: dragStepUnit 'day' 7일, basePxPerDragStep 28 -> 하루 4px
-    // 예전: DST가 낀 3월이 30.96일로 잘려 124px 대신 120px이 되었다
+  it('sizes year-scale month cells by the real calendar month length', () => {
+    // year: dragStepUnit 'day' with 7 days, basePxPerDragStep 28 -> 4px per day
+    // Before: March, which contains a DST change, was truncated to 30.96 days and came out 120px instead of 124px
     withTimeZone('America/New_York', () => {
       const cells = computeTimelineData(
         [task('2025-02-01T00:00:00Z', '2025-07-01T00:00:00Z')],
@@ -65,17 +65,17 @@ describe('DST 경계에서의 타임라인 셀 (#28)', () => {
         cells.map((c) => [c.startDate.format('YYYY-MM'), c.widthPx]),
       );
       expect(byMonth.get('2025-02')).toBe(28 * 4);
-      expect(byMonth.get('2025-03')).toBe(31 * 4); // DST 있음
+      expect(byMonth.get('2025-03')).toBe(31 * 4); // has DST
       expect(byMonth.get('2025-04')).toBe(30 * 4);
-      expect(byMonth.get('2025-11')).toBe(30 * 4); // DST 있음
+      expect(byMonth.get('2025-11')).toBe(30 * 4); // has DST
     });
   });
 });
 
 describe('shiftByDragSteps (#28)', () => {
-  it('달력 단위로 더해 봄 DST를 가로질러도 시각이 유지된다', () => {
-    // 로컬 모드 인스턴스로도 검증 - 분으로 환산해 더하던 예전 방식은
-    // 3/8 23:30 EST + 1440분 = 3/10 00:30 EDT 로 하루가 아니라 이틀 뒤 칸에 떨어졌다
+  it('adds calendar units, so the time of day survives a spring DST crossing', () => {
+    // Checked with a local-mode instance too - the old approach of adding minutes made
+    // 3/8 23:30 EST + 1440 min = 3/10 00:30 EDT, landing two days later instead of one
     withTimeZone('America/New_York', () => {
       const start = localDayjs('2025-03-08T23:30');
       expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
@@ -90,8 +90,8 @@ describe('shiftByDragSteps (#28)', () => {
     });
   });
 
-  it('달력 단위로 더해 가을 DST를 가로질러도 시각이 유지된다', () => {
-    // 예전: 11/1 23:30 EDT + 1440분 = 11/2 22:30 EST (하루가 25시간이라 한 시간 모자람)
+  it('adds calendar units, so the time of day survives a fall DST crossing', () => {
+    // Before: 11/1 23:30 EDT + 1440 min = 11/2 22:30 EST (an hour short, because that day is 25 hours)
     withTimeZone('America/New_York', () => {
       const start = localDayjs('2025-11-01T23:30');
       expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
@@ -100,7 +100,7 @@ describe('shiftByDragSteps (#28)', () => {
     });
   });
 
-  it('year 스케일 7일 스텝도 DST를 가로질러 정확히 7일씩 움직인다', () => {
+  it('moves exactly 7 days per step at year scale, even across DST', () => {
     withTimeZone('America/New_York', () => {
       const start = localDayjs('2025-03-05T09:00');
       expect(shiftByDragSteps(start, 1, 'year').format('YYYY-MM-DD HH:mm')).toBe(
@@ -109,23 +109,23 @@ describe('shiftByDragSteps (#28)', () => {
     });
   });
 
-  it('스케일별 드래그 스텝이 config 그대로다', () => {
+  it('takes the drag step for each scale straight from the config', () => {
     const base = dayjs('2025-01-01T00:00:00Z');
     expect(shiftByDragSteps(base, 3, 'day').toISOString()).toBe('2025-01-01T03:00:00.000Z');
     expect(shiftByDragSteps(base, 3, 'week').toISOString()).toBe('2025-01-01T18:00:00.000Z');
     expect(shiftByDragSteps(base, 3, 'month').toISOString()).toBe('2025-01-04T00:00:00.000Z');
     expect(shiftByDragSteps(base, 3, 'year').toISOString()).toBe('2025-01-22T00:00:00.000Z');
-    // month 스케일 스텝을 30일 고정으로 환산하면 실제 달 길이와 어긋난다
+    // Converting a month-scale step into a fixed 30 days would not match the real month length
     expect(shiftByDragSteps(dayjs('2025-01-31T00:00:00Z'), 30, 'month').toISOString()).toBe(
       '2025-03-02T00:00:00.000Z',
     );
   });
 });
 
-describe('UTC 기준 배치 (#84)', () => {
+describe('UTC-based positioning (#84)', () => {
   const boundary = task('2025-03-10T23:00:00Z', '2025-03-11T05:00:00Z');
 
-  it('뷰어 타임존이 달라도 같은 데이터가 같은 위치에 그려진다', () => {
+  it('draws the same data at the same position whatever the viewer time zone', () => {
     const seoul = withTimeZone('Asia/Seoul', () => computeTimelineData([boundary], 'month'));
     const london = withTimeZone('Europe/London', () =>
       computeTimelineData([boundary], 'month'),
@@ -138,8 +138,8 @@ describe('UTC 기준 배치 (#84)', () => {
     );
   });
 
-  it('UTC 날짜 경계 태스크가 UTC 달력 칸에 붙는다', () => {
-    // 3/10 23:00Z 시작 -> "Mar 10" 칸의 23/24 지점
+  it('sticks a task on a UTC date boundary to the UTC calendar cell', () => {
+    // Starts 3/10 23:00Z -> 23/24 of the way into the "Mar 10" cell
     const { bottomCells, transformedTasks } = withTimeZone('Asia/Seoul', () =>
       computeTimelineData([boundary], 'month'),
     );
@@ -152,18 +152,18 @@ describe('UTC 기준 배치 (#84)', () => {
     expect(transformedTasks[0].barWidth).toBeCloseTo((32 * 6) / 24, 5);
   });
 
-  it('셀 라벨과 헤더가 UTC 달력 날짜를 쓴다', () => {
+  it('uses UTC calendar dates for cell labels and headers', () => {
     const { bottomCells } = withTimeZone('Asia/Seoul', () =>
       computeTimelineData([task('2025-06-01T00:00:00Z', '2025-06-02T00:00:00Z')], 'month'),
     );
     const labels = bottomCells.map((c) => GANTT_SCALE_CONFIG.month.formatTickLabel?.(c.startDate));
 
-    // 첫 셀은 6/1에서 5틱 앞선 5/27
+    // The first cell is 5/27, five ticks before 6/1
     expect(bottomCells[0].startDate.toISOString()).toBe('2025-05-27T00:00:00.000Z');
     expect(labels.slice(0, 6)).toEqual(['27', '28', '29', '30', '31', '1']);
   });
 
-  it('존 없는 문자열은 UTC 벽시계로 읽어 적은 그대로 표시한다', () => {
+  it('reads a zone-less string as a UTC wall clock and shows it exactly as written', () => {
     withTimeZone('Asia/Seoul', () => {
       expect(dayjs('2025-06-01T09:00').format('YYYY-MM-DD HH:mm')).toBe('2025-06-01 09:00');
       expect(dayjs('2025-06-01').toISOString()).toBe('2025-06-01T00:00:00.000Z');

--- a/src/utils/timezone.test.ts
+++ b/src/utils/timezone.test.ts
@@ -1,0 +1,172 @@
+import localDayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import { GANTT_SCALE_CONFIG } from 'constants/gantt';
+import type { Task } from 'types/task';
+import dayjs from 'utils/dayjs';
+import { computeTimelineData, shiftByDragSteps } from './timeline';
+
+/**
+ * 테스트 동안만 뷰어의 로컬 타임존을 바꾼다.
+ * (Node는 process.env.TZ 대입 즉시 Date 계산에 반영한다)
+ */
+function withTimeZone<T>(tz: string, fn: () => T): T {
+  const prev = process.env.TZ;
+  process.env.TZ = tz;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.TZ;
+    else process.env.TZ = prev;
+  }
+}
+
+const task = (startDate: string, endDate: string): Task => ({
+  id: 'a',
+  name: 'a',
+  startDate,
+  endDate,
+  parentId: null,
+  sequence: '1',
+});
+
+const widths = (t: Task, scale: 'day' | 'week' | 'month' | 'year') =>
+  computeTimelineData([t], scale).bottomCells.map((c) => c.widthPx);
+
+// America/New_York: 2025-03-09 는 23시간(봄 DST), 2025-11-02 는 25시간(가을 DST)
+const SPRING_FORWARD = task('2025-03-08T00:00:00Z', '2025-03-10T00:00:00Z');
+const FALL_BACK = task('2025-11-01T00:00:00Z', '2025-11-03T00:00:00Z');
+
+describe('DST 경계에서의 타임라인 셀 (#28)', () => {
+  it('봄 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
+    // 예전: 23시간짜리 하루가 diff('day') 정수 절삭으로 0일이 되어 3/9 셀이 0px로 사라졌다
+    withTimeZone('America/New_York', () => {
+      expect(new Set(widths(SPRING_FORWARD, 'month'))).toEqual(new Set([32]));
+      expect(new Set(widths(SPRING_FORWARD, 'week'))).toEqual(new Set([216]));
+    });
+  });
+
+  it('가을 DST가 낀 주에도 하루 셀 너비가 균일하다', () => {
+    // 예전: 25시간짜리 하루가 week 스케일에서 225px(다른 날은 216px)로 튀었다
+    withTimeZone('America/New_York', () => {
+      expect(new Set(widths(FALL_BACK, 'month'))).toEqual(new Set([32]));
+      expect(new Set(widths(FALL_BACK, 'week'))).toEqual(new Set([216]));
+    });
+  });
+
+  it('year 스케일 월 셀 너비가 실제 달력 월 길이를 따른다', () => {
+    // year: dragStepUnit 'day' 7일, basePxPerDragStep 28 -> 하루 4px
+    // 예전: DST가 낀 3월이 30.96일로 잘려 124px 대신 120px이 되었다
+    withTimeZone('America/New_York', () => {
+      const cells = computeTimelineData(
+        [task('2025-02-01T00:00:00Z', '2025-07-01T00:00:00Z')],
+        'year',
+      ).bottomCells;
+      const byMonth = new Map(
+        cells.map((c) => [c.startDate.format('YYYY-MM'), c.widthPx]),
+      );
+      expect(byMonth.get('2025-02')).toBe(28 * 4);
+      expect(byMonth.get('2025-03')).toBe(31 * 4); // DST 있음
+      expect(byMonth.get('2025-04')).toBe(30 * 4);
+      expect(byMonth.get('2025-11')).toBe(30 * 4); // DST 있음
+    });
+  });
+});
+
+describe('shiftByDragSteps (#28)', () => {
+  it('달력 단위로 더해 봄 DST를 가로질러도 시각이 유지된다', () => {
+    // 로컬 모드 인스턴스로도 검증 - 분으로 환산해 더하던 예전 방식은
+    // 3/8 23:30 EST + 1440분 = 3/10 00:30 EDT 로 하루가 아니라 이틀 뒤 칸에 떨어졌다
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-03-08T23:30');
+      expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-09 23:30',
+      );
+      expect(shiftByDragSteps(start, 2, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-10 23:30',
+      );
+      expect(shiftByDragSteps(start, -1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-07 23:30',
+      );
+    });
+  });
+
+  it('달력 단위로 더해 가을 DST를 가로질러도 시각이 유지된다', () => {
+    // 예전: 11/1 23:30 EDT + 1440분 = 11/2 22:30 EST (하루가 25시간이라 한 시간 모자람)
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-11-01T23:30');
+      expect(shiftByDragSteps(start, 1, 'month').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-11-02 23:30',
+      );
+    });
+  });
+
+  it('year 스케일 7일 스텝도 DST를 가로질러 정확히 7일씩 움직인다', () => {
+    withTimeZone('America/New_York', () => {
+      const start = localDayjs('2025-03-05T09:00');
+      expect(shiftByDragSteps(start, 1, 'year').format('YYYY-MM-DD HH:mm')).toBe(
+        '2025-03-12 09:00',
+      );
+    });
+  });
+
+  it('스케일별 드래그 스텝이 config 그대로다', () => {
+    const base = dayjs('2025-01-01T00:00:00Z');
+    expect(shiftByDragSteps(base, 3, 'day').toISOString()).toBe('2025-01-01T03:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'week').toISOString()).toBe('2025-01-01T18:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'month').toISOString()).toBe('2025-01-04T00:00:00.000Z');
+    expect(shiftByDragSteps(base, 3, 'year').toISOString()).toBe('2025-01-22T00:00:00.000Z');
+    // month 스케일 스텝을 30일 고정으로 환산하면 실제 달 길이와 어긋난다
+    expect(shiftByDragSteps(dayjs('2025-01-31T00:00:00Z'), 30, 'month').toISOString()).toBe(
+      '2025-03-02T00:00:00.000Z',
+    );
+  });
+});
+
+describe('UTC 기준 배치 (#84)', () => {
+  const boundary = task('2025-03-10T23:00:00Z', '2025-03-11T05:00:00Z');
+
+  it('뷰어 타임존이 달라도 같은 데이터가 같은 위치에 그려진다', () => {
+    const seoul = withTimeZone('Asia/Seoul', () => computeTimelineData([boundary], 'month'));
+    const london = withTimeZone('Europe/London', () =>
+      computeTimelineData([boundary], 'month'),
+    );
+
+    expect(seoul.transformedTasks[0].barLeft).toBe(london.transformedTasks[0].barLeft);
+    expect(seoul.transformedTasks[0].barWidth).toBe(london.transformedTasks[0].barWidth);
+    expect(seoul.bottomCells.map((c) => c.startDate.toISOString())).toEqual(
+      london.bottomCells.map((c) => c.startDate.toISOString()),
+    );
+  });
+
+  it('UTC 날짜 경계 태스크가 UTC 달력 칸에 붙는다', () => {
+    // 3/10 23:00Z 시작 -> "Mar 10" 칸의 23/24 지점
+    const { bottomCells, transformedTasks } = withTimeZone('Asia/Seoul', () =>
+      computeTimelineData([boundary], 'month'),
+    );
+    const index = bottomCells.findIndex(
+      (c) => c.startDate.format('YYYY-MM-DD') === '2025-03-10',
+    );
+
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(transformedTasks[0].barLeft).toBeCloseTo(index * 32 + (32 * 23) / 24, 5);
+    expect(transformedTasks[0].barWidth).toBeCloseTo((32 * 6) / 24, 5);
+  });
+
+  it('셀 라벨과 헤더가 UTC 달력 날짜를 쓴다', () => {
+    const { bottomCells } = withTimeZone('Asia/Seoul', () =>
+      computeTimelineData([task('2025-06-01T00:00:00Z', '2025-06-02T00:00:00Z')], 'month'),
+    );
+    const labels = bottomCells.map((c) => GANTT_SCALE_CONFIG.month.formatTickLabel?.(c.startDate));
+
+    // 첫 셀은 6/1에서 5틱 앞선 5/27
+    expect(bottomCells[0].startDate.toISOString()).toBe('2025-05-27T00:00:00.000Z');
+    expect(labels.slice(0, 6)).toEqual(['27', '28', '29', '30', '31', '1']);
+  });
+
+  it('존 없는 문자열은 UTC 벽시계로 읽어 적은 그대로 표시한다', () => {
+    withTimeZone('Asia/Seoul', () => {
+      expect(dayjs('2025-06-01T09:00').format('YYYY-MM-DD HH:mm')).toBe('2025-06-01 09:00');
+      expect(dayjs('2025-06-01').toISOString()).toBe('2025-06-01T00:00:00.000Z');
+    });
+  });
+});

--- a/src/utils/transformData.ts
+++ b/src/utils/transformData.ts
@@ -41,7 +41,7 @@ export function transformTasks(
     const order = index + 1;
 
     // Calculate bar position and width
-    // 마일스톤은 startDate 한 점 기준 (endDate 무시)
+    // Milestones are a single point at startDate (endDate is ignored)
     const { barMarginLeftAmount, barWidthSize } = calculateDateOffsets(
       dayjs(task.startDate),
       isMilestoneTask(task) ? dayjs(task.startDate) : dayjs(task.endDate),

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -7,7 +7,13 @@ import {
   NODE_HEIGHT,
 } from 'constants/gantt';
 import { normalizeProgress, type Task, type TaskTransformed } from 'types/task';
-import { buildDependencies, getSmartGanttPath } from './arrowPath';
+import {
+  buildDependencies,
+  buildTaskIndex,
+  getSmartGanttPath,
+  isArrowVisible,
+  type ArrowViewport,
+} from './arrowPath';
 import { mergeHeaderGroups } from './headerUtils';
 import {
   calculateDateOffsetPx,
@@ -235,16 +241,23 @@ describe('buildDependencies', () => {
     originalOrder: order,
     ...extra,
   });
-  const chain = (extra: Partial<TaskTransformed> = {}) => [
-    bar('a', 1, 100, extra),
-    bar('b', 2, 300, { dependencies: [{ targetId: 'a', type: 'FS' }] }),
-  ];
+  const chain = (extra: Partial<TaskTransformed> = {}) =>
+    buildTaskIndex([
+      bar('a', 1, 100, extra),
+      bar('b', 2, 300, { dependencies: [{ targetId: 'a', type: 'FS' }] }),
+    ]);
   const center = NODE_HEIGHT / 2;
 
   it('anchors an FS arrow from the predecessor end to the successor start', () => {
     expect(buildDependencies(chain(), {})).toEqual([
       { targetId: 'a', type: 'FS', fromX: 164, fromY: center, toX: 300, toY: NODE_HEIGHT + center },
     ]);
+  });
+
+  it('indexes tasks by id and keeps task order for iteration', () => {
+    const index = buildTaskIndex([bar('a', 1, 100), bar('b', 2, 300)]);
+    expect([...index.keys()]).toEqual(['a', 'b']);
+    expect(index.get('b')?.barLeft).toBe(300);
   });
 
   it('follows the live offset of whichever end is being dragged', () => {
@@ -275,11 +288,11 @@ describe('buildDependencies', () => {
     const unknownDep = [
       { targetId: 'a', type: 'fs' },
     ] as unknown as TaskTransformed['dependencies'];
-    const tasks = [
+    const tasks = buildTaskIndex([
       bar('a', 1, 100),
       bar('b', 2, 300, { dependencies: unknownDep }),
       bar('c', 3, 500, { dependencies: unknownDep }),
-    ];
+    ]);
 
     expect(buildDependencies(tasks, {})).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
@@ -288,8 +301,52 @@ describe('buildDependencies', () => {
 
   it('skips dependencies pointing at a task that is not in the chart', () => {
     expect(
-      buildDependencies([bar('b', 1, 300, { dependencies: [{ targetId: 'gone', type: 'FS' }] })], {}),
+      buildDependencies(
+        buildTaskIndex([
+          bar('b', 1, 300, { dependencies: [{ targetId: 'gone', type: 'FS' }] }),
+        ]),
+        {},
+      ),
     ).toEqual([]);
+  });
+});
+
+describe('isArrowVisible', () => {
+  // 가로 100~500, 세로 100~300 이 보이는 상황
+  const viewport: ArrowViewport = {
+    topPx: 100,
+    bottomPx: 300,
+    isBarVisible: (left, width) => left + width >= 100 && left <= 500,
+  };
+  const arrow = (fromX: number, fromY: number, toX: number, toY: number) => ({
+    fromX,
+    fromY,
+    toX,
+    toY,
+  });
+
+  it('keeps arrows that overlap the viewport', () => {
+    expect(isArrowVisible(arrow(200, 150, 300, 250), viewport)).toBe(true);
+  });
+
+  it('drops arrows fully above, below, left of, or right of the viewport', () => {
+    expect(isArrowVisible(arrow(200, 0, 300, 40), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(200, 400, 300, 450), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(0, 150, 40, 250), viewport)).toBe(false);
+    expect(isArrowVisible(arrow(600, 150, 700, 250), viewport)).toBe(false);
+  });
+
+  it('keeps an arrow whose ends straddle the viewport on either axis', () => {
+    // 위/아래 끝이 모두 화면 밖이지만 선이 화면을 세로로 관통한다
+    expect(isArrowVisible(arrow(200, 0, 300, 500), viewport)).toBe(true);
+    // 좌/우도 마찬가지
+    expect(isArrowVisible(arrow(0, 150, 900, 250), viewport)).toBe(true);
+  });
+
+  it('allows for the elbow overshooting the endpoints', () => {
+    // 꺾인 경로가 끝점 바깥으로 조금 나가므로 경계 근처는 살려 둔다
+    expect(isArrowVisible(arrow(80, 150, 90, 250), viewport)).toBe(true);
+    expect(isArrowVisible(arrow(200, 60, 300, 80), viewport)).toBe(true);
   });
 });
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -166,7 +166,7 @@ describe('GANTT_SCALE_CONFIG labels', () => {
     expect(GANTT_SCALE_CONFIG.week.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
     expect(GANTT_SCALE_CONFIG.month.formatHeaderLabel?.(afternoon)).toBe('Sep 2025');
     expect(GANTT_SCALE_CONFIG.year.formatHeaderLabel?.(afternoon)).toBe('2025');
-    expect(afternoon.format(DATE_FORMATS.day)).toBe('Sep 1, 2025 15:00');
+    expect(afternoon.format(DATE_FORMATS.day)).toBe('Sep 1, 2025 15:00 UTC');
     expect(afternoon.format(DATE_FORMATS.week)).toBe('Sep 1, 2025');
   });
 });

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -262,15 +262,15 @@ describe('buildDependencies', () => {
   });
 
   it('follows the live offset of whichever end is being dragged', () => {
-    // 선행(A)을 드래그하면 화살표 시작점이 따라와야 한다 (#66)
+    // Dragging the predecessor (A) has to bring the arrow's start point along (#66)
     expect(
       buildDependencies(chain(), { a: { offsetX: 32, offsetWidth: 0 } })[0],
     ).toMatchObject({ fromX: 196, toX: 300 });
-    // 선행의 우측 리사이즈도 마찬가지
+    // Same for resizing the predecessor's right edge
     expect(
       buildDependencies(chain(), { a: { offsetX: 0, offsetWidth: 32 } })[0],
     ).toMatchObject({ fromX: 196, toX: 300 });
-    // 후행(B)을 드래그하면 도착점만 움직인다
+    // Dragging the successor (B) moves only the end point
     expect(
       buildDependencies(chain(), { b: { offsetX: -32, offsetWidth: 0 } })[0],
     ).toMatchObject({ fromX: 164, toX: 268 });
@@ -285,7 +285,7 @@ describe('buildDependencies', () => {
 
   it('skips an unrecognized dependency type instead of throwing, warning once', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    // consumer가 넘기는 JSON에는 타입 밖의 값이 올 수 있다
+    // Consumer-supplied JSON can carry values outside the type
     const unknownDep = [
       { targetId: 'a', type: 'fs' },
     ] as unknown as TaskTransformed['dependencies'];
@@ -313,7 +313,7 @@ describe('buildDependencies', () => {
 });
 
 describe('isArrowVisible', () => {
-  // 가로 100~500, 세로 100~300 이 보이는 상황
+  // Visible area: 100-500 horizontally, 100-300 vertically
   const viewport: ArrowViewport = {
     topPx: 100,
     bottomPx: 300,
@@ -338,14 +338,14 @@ describe('isArrowVisible', () => {
   });
 
   it('keeps an arrow whose ends straddle the viewport on either axis', () => {
-    // 위/아래 끝이 모두 화면 밖이지만 선이 화면을 세로로 관통한다
+    // Both the top and bottom ends are off-screen, but the line crosses the viewport vertically
     expect(isArrowVisible(arrow(200, 0, 300, 500), viewport)).toBe(true);
-    // 좌/우도 마찬가지
+    // Same on the left/right axis
     expect(isArrowVisible(arrow(0, 150, 900, 250), viewport)).toBe(true);
   });
 
   it('allows for the elbow overshooting the endpoints', () => {
-    // 꺾인 경로가 끝점 바깥으로 조금 나가므로 경계 근처는 살려 둔다
+    // The elbowed path runs a little past the endpoints, so arrows near the boundary are kept
     expect(isArrowVisible(arrow(80, 150, 90, 250), viewport)).toBe(true);
     expect(isArrowVisible(arrow(200, 60, 300, 80), viewport)).toBe(true);
   });


### PR DESCRIPTION
The rest of the 0.5 milestone: rendering performance, date correctness, and the English translation sweep. Everything here was measured or reproduced, not assumed.

## Rendering performance (#26)

Three problems compounded on every drag frame:

- `buildDependencies` resolved each dependency's target with `transformedTasks.find(...)` inside a loop over all tasks — quadratic, and re-run on every frame. It now takes a Map built once per data change.
- Arrows were never culled. Every dependency in the dataset rendered every frame, however far off-screen. A pure `isArrowVisible` predicate now clips them to the same window the bars use, as a bounding-box test so an arrow whose endpoints straddle the viewport is still drawn.
- The header rendered every bottom-row cell. At day scale over a long range that is tens of thousands of DOM nodes. The column virtualizer that already existed but was never consumed now drives that row.

Measured on 1,000 tasks / 1,039 dependencies over a 1,000-day span (Chrome, demo data reverted before commit):

| month scale, middle of the dataset | before | after |
|---|---|---|
| dependency arrows in the DOM | 1,038 | 61 |
| header cells in the DOM | 1,013 | 66 |
| drag frame, mean / p95 | 11.4 / 24.8 ms | 1.0 / 1.5 ms |

At day scale over the same range: 24,058 header cells → 61, chart DOM 27,316 → 2,323 nodes, and switching scales dropped from 3,469 ms to 242 ms. Correctness was checked alongside: all 22 arrows on the demo dataset anchor to the right bar edges, scrolling away culls them and scrolling back restores all 22.

## DST-safe drags and a UTC timeline (#28, #84)

The drag hook converted a drag into **minutes** through a fixed table (`day: 60*24`, `week: 60*24*7`, `month: 60*24*30`) and then added those minutes. A calendar day is 23 or 25 hours across a DST boundary, so a one-day drag landed an hour off — and `month: 30 days` was simply wrong in every month. In `America/New_York`, dragging a task at `2025-03-08 23:30` forward one day produced **`2025-03-10 00:30`**; it now produces `2025-03-09 23:30`. Drags go through a single `shiftByDragSteps()` helper that adds real calendar units, used by both the live preview and the commit so they cannot diverge.

Separately, the README has always documented task dates as UTC ISO strings while the code parsed and positioned them in the viewer's local timezone — the same data rendered differently depending on where the viewer sat, and a task on a UTC day boundary showed on the wrong day. **The timeline is now drawn and labeled in UTC**, which makes the documented contract true. Zone-less input like `"2025-06-01T09:00"` is read as UTC wall-clock and renders exactly as written, so a team that wants its own zone passes local wall-clock strings.

⚠️ **This is behavior-breaking** for anyone passing `Z` instants and expecting local-time placement: their bars move to UTC positions. That shift *is* the fix for #84, and it is documented in a new "Time zone" section in the README, including that `holidays` and `isNonWorkingDay` now operate on UTC days.

11 new tests cover this, each confirmed failing against the pre-fix code first. The suite passes under `America/New_York`, `Asia/Seoul`, `UTC`, and `Australia/Lord_Howe`.

## English translation sweep (#30)

27 files carried Korean code comments, and three user-facing `aria-label`s were Korean — screen-reader users heard Korean regardless of app locale. All translated, comments and labels only; the diff contains no logic changes and the test count is unchanged.

## Verification

`pnpm lint` (0 errors; the 4 warnings are pre-existing react-compiler notes), `pnpm type-check`, `pnpm test` (53 passing, up from 37), `pnpm build`, plus a local SSR render of the built package — all green. The merged result was also exercised in the browser: arrows and header cells are culled as expected, no console errors, and the chart renders correctly at every scale in both themes.

Closes #26
Closes #28
Closes #84
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
