### PR TITLE
feat: task events, cancellable async changes, and render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ Currently, this project is built specifically for React due to my development ba
   - Snap to configured intervals
 - 🧲 Smart dependency arrows (FS, SS, FF, SF)
 - ◆ Milestones and per-task progress
+- 🖱️ Click / double-click / select events with a visible selection highlight
+- ↩️ Cancellable before-events: veto a move, resize or progress change and the bar rolls back
+- 🎨 Per-task color and class name, plus `renderBar` / `renderTooltip` / `renderHeaderCell` overrides
 - 🗓️ Weekend and holiday shading
 - ⚡ Virtualized rendering for performance
 - 🌙 Light/Dark/System theme support
 - 📍 Today marker indicator
-- 💬 Drag tooltip showing date changes
+- 💬 Hover and drag tooltips
 - 📦 Lightweight with minimal dependencies
 
 ## 📺 [Demo](https://jaeungkim.com/gantt-chart)
@@ -110,6 +113,15 @@ export default function App() {
 | `collapsedIds` | `string[]` | - | Ids of collapsed parents (controlled) |
 | `defaultCollapsedIds` | `string[]` | - | Initial collapsed ids (uncontrolled seed) |
 | `onCollapsedChange` | `(ids: string[]) => void` | - | Fires whenever a row is expanded or collapsed |
+| `onTaskClick` | `(task, event) => void` | - | A bar or task-list row was clicked. Not fired for the click that ends a drag |
+| `onTaskDoubleClick` | `(task, event) => void` | - | A bar or row was double-clicked |
+| `onTaskSelect` | `(task \| null) => void` | - | The selection changed; `null` when the empty timeline is clicked. Passing it turns selection on |
+| `selectable` | `boolean` | `onTaskSelect !== undefined` | Selection highlight without a callback (`true`), or off entirely (`false`) |
+| `onBeforeTaskChange` | `(change) => boolean \| void \| Promise<boolean \| void>` | - | Runs before a move, resize or progress change is written. `false`, a promise resolving to `false`, or a rejection rolls the bar back |
+| `renderBar` | `(props) => ReactNode` | - | Replaces the bar node entirely |
+| `renderTooltip` | `(props) => ReactNode` | - | Replaces the tooltip node entirely, for hover and drag alike |
+| `renderHeaderCell` | `(props) => ReactNode` | - | Replaces a timeline header cell entirely; both header rows go through it |
+| `showTooltip` | `boolean` | `true` | `false` suppresses the hover and drag tooltips |
 
 ## Task List and Hierarchy
 
@@ -178,6 +190,161 @@ With `hierarchy` on, `parentId` becomes the source of truth:
 Collapse state is controlled with `collapsedIds` and uncontrolled with `defaultCollapsedIds`;
 `onCollapsedChange` fires either way, so a host can persist it wherever it likes.
 
+## Events and Selection
+
+```tsx
+<ReactGanttChart
+  tasks={tasks}
+  onTaskClick={(task, event) => console.log('clicked', task.id, event.shiftKey)}
+  onTaskDoubleClick={(task) => openEditor(task.id)}
+  onTaskSelect={(task) => setSelectedId(task?.id ?? null)}
+/>
+```
+
+Both panes fire the same events: a click on a bar and a click on its task-list row are the
+same event, and the selected row is highlighted in both places at once.
+
+- Passing `onTaskSelect` turns selection on. Pass `selectable` explicitly for the highlight
+  without a callback (`selectable`) or to turn it off (`selectable={false}`).
+- `onTaskSelect` fires only when the selection actually changes; clicking the empty timeline
+  clears it and reports `null`.
+- The click that ends a drag is swallowed, so dragging a bar never registers as a click.
+- A double click is still two clicks in the DOM: `onTaskClick` fires twice and
+  `onTaskDoubleClick` once. Key off the double click, not off a click count.
+
+## Cancellable Changes and Optimistic Updates
+
+`onBeforeTaskChange` runs after the gesture ends and before anything is written. It is the
+persistence hook: `await` your API, and answer.
+
+| The handler returns | What happens |
+|---------------------|--------------|
+| nothing, or `true` | The change is committed and `onTasksChange` fires |
+| `false` | The change is dropped and the bar animates back |
+| a promise resolving to anything but `false` | Committed once it settles |
+| a promise resolving to `false` | Rolled back once it settles |
+| a rejected promise, or a synchronous throw | Rolled back - the failed-server case |
+
+While the promise is pending the bar **stays where the user dropped it** — nothing is
+disabled, nothing is frozen, and the user can keep working. If they start another gesture on
+that same bar before the answer arrives, the late answer is dropped: the newer gesture owns
+the bar and gets its own decision. Moves and resizes share one lane per task; a progress edit
+runs in its own, so a pending date change and a progress change never cancel each other.
+
+```tsx
+function Schedule() {
+  const [tasks, setTasks] = useState(initialTasks);
+
+  return (
+    <ReactGanttChart
+      tasks={tasks}
+      // The bar is already where the user dropped it while this runs
+      onBeforeTaskChange={async (change) => {
+        try {
+          const response = await fetch('/api/tasks/bulk', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(
+              change.changedTasks.map((task) => ({
+                id: task.id,
+                startDate: task.startDate,
+                endDate: task.endDate,
+                progress: task.progress,
+              })),
+            ),
+          });
+
+          // A 409 from the server rolls the bar back to where the drag started
+          if (!response.ok) return false;
+        } catch (error) {
+          // Network failure - same thing, and the bar never lies about what was saved
+          toast.error('Could not save the change');
+          return false;
+        }
+      }}
+      // Only reached once the change is accepted
+      onTasksChange={setTasks}
+    />
+  );
+}
+```
+
+The payload:
+
+```ts
+interface GanttTaskChange {
+  type: 'move' | 'resize' | 'progress';
+  task: Task;             // the bar the user grabbed, in its new shape
+  changedTasks: Task[];   // every task this gesture rewrites (a summary drag carries its subtree)
+  previousTasks: Task[];  // the same tasks before the gesture, index for index
+  tasks: Task[];          // the full array onTasksChange would receive
+  edge?: 'start' | 'end'; // resize only
+}
+```
+
+Dragging a summary bar moves its whole subtree, so `changedTasks` holds every descendant —
+one handler call, one veto decision, one `onTasksChange` for the lot.
+
+## Custom Rendering
+
+### Per-task color and class
+
+```tsx
+const tasks: Task[] = [
+  { id: '1', name: 'Design', color: '#7c3aed', className: 'is-critical', /* ... */ },
+];
+```
+
+`color` takes any CSS color. The progress fill and the hover shade are derived from it, so
+one value colors the whole bar; without it the `--gantt-*` theme tokens decide as before.
+`className` lands on the bar and on the task's row in the list pane.
+
+### Render props
+
+Each of these replaces the default node completely.
+
+```tsx
+<ReactGanttChart
+  tasks={tasks}
+  // Spread barProps to keep positioning, dragging, clicks and double clicks working
+  renderBar={({ task, width, progress, isSelected, barProps }) => (
+    <div {...barProps} className={`my-bar${isSelected ? ' is-selected' : ''}`}>
+      <span style={{ width: `${progress ?? 0}%` }} className="my-fill" />
+      {width > 80 ? task.name : null}
+    </div>
+  )}
+  // reason is 'hover' while pointing at a bar, or the gesture in progress
+  renderTooltip={({ task, reason, startDate, endDate, durationMs }) =>
+    reason === 'hover' ? (
+      <div className="my-tip">
+        {task.name} · {Math.round(durationMs / 86_400_000)}d
+      </div>
+    ) : (
+      <div className="my-tip">
+        {startDate.format('MMM D')} → {endDate.format('MMM D')}
+      </div>
+    )
+  }
+  // row is 'top' for the merged group labels, 'bottom' for the time ticks
+  renderHeaderCell={({ row, label, date, cellProps }) => (
+    <div {...cellProps} title={date.toISOString()}>
+      {row === 'top' ? label.toUpperCase() : label}
+    </div>
+  )}
+/>
+```
+
+- `renderBar` receives `task`, `left`, `width`, `height`, `progress`, `scale`, `isMilestone`,
+  `isSummary`, `isDragging`, `isSelected` and `barProps`. It owns the whole bar, tooltip
+  included — render a `.gantt-bar-tooltip` child yourself if you want one.
+- `renderTooltip` receives `task`, `reason`, `startDate`, `endDate`, `durationMs`, `progress`
+  and `scale`. The dates are the live values while a gesture is running.
+- `renderHeaderCell` receives `row`, `date`, `label`, `width`, `scale` and `cellProps`.
+  Spreading `cellProps` keeps the header layout intact.
+
+A hover tooltip (name, dates, duration, progress) is on by default. `showTooltip={false}`
+turns off both it and the drag tooltip.
+
 ## Imperative API
 
 Pass a ref to scroll the chart programmatically:
@@ -211,6 +378,8 @@ interface Task {
   sequence: string;
   type?: 'task' | 'milestone';   // milestones render as a diamond at startDate
   progress?: number;             // 0-100, draws a fill inside the bar
+  color?: string;                // any CSS color; the fill and hover shade derive from it
+  className?: string;            // added to this task's bar and its task-list row
   dependencies?: TaskDependency[];
 }
 
@@ -284,7 +453,7 @@ The stylesheet loads no remote fonts; it uses the system font stack unless you o
 - [x] Collapsible parent-child rows
 - [ ] Inline editing for task names
 - [ ] Export to PNG/SVG
-- [ ] Custom bar colors
+- [x] Custom bar colors
 
 ## 🤝 Contributing
 

--- a/src/assets/styles/gantt.css
+++ b/src/assets/styles/gantt.css
@@ -328,6 +328,12 @@
   font-weight: 600;
 }
 
+/* Selected row - marked in the same beat as its bar */
+.gantt-grid-row.selected {
+  background: var(--gantt-muted);
+  box-shadow: inset 2px 0 0 var(--gantt-accent);
+}
+
 .gantt-grid-cell {
   display: flex;
   align-items: center;
@@ -638,7 +644,8 @@
   z-index: 10;
   display: flex;
   align-items: center;
-  background: var(--gantt-bar-bg);
+  /* --gantt-bar-color is set inline from a task's color; without one the theme token decides */
+  background: var(--gantt-bar-color, var(--gantt-bar-bg));
   border-radius: 6px;
   user-select: none;
   cursor: grab;
@@ -671,7 +678,7 @@
 }
 
 .gantt-task-bar:hover {
-  background: var(--gantt-bar-bg-hover);
+  background: var(--gantt-bar-color-hover, var(--gantt-bar-bg-hover));
   box-shadow: var(--gantt-bar-shadow-hover);
 }
 
@@ -694,12 +701,12 @@
 
 /* Summary bar: a flat span over the children's range - no resize handles either */
 .gantt-task-bar.summary {
-  background: var(--gantt-milestone-bg);
+  background: var(--gantt-bar-color, var(--gantt-milestone-bg));
   border-radius: 3px;
 }
 
 .gantt-task-bar.summary:hover {
-  background: var(--gantt-milestone-bg-hover);
+  background: var(--gantt-bar-color-hover, var(--gantt-milestone-bg-hover));
 }
 
 .gantt-task-bar.summary .gantt-task-name {
@@ -711,7 +718,7 @@
 }
 
 .gantt-task-bar.summary .gantt-progress-fill {
-  background: var(--gantt-foreground);
+  background: var(--gantt-progress-color, var(--gantt-foreground));
   opacity: 0.35;
   border-radius: 3px 0 0 3px;
 }
@@ -721,6 +728,30 @@
 .gantt-task-bar.summary:hover::before,
 .gantt-task-bar.summary:hover::after {
   opacity: 0;
+}
+
+/* ===== SELECTION ===== */
+.gantt-task-bar.selected,
+.gantt-milestone.selected .gantt-milestone-diamond {
+  outline: 2px solid var(--gantt-accent);
+  outline-offset: 2px;
+}
+
+/* ===== VETOED CHANGE ===== */
+/* The bar holds the dropped position while a before-handler runs; when the answer is a
+   veto the offsets drop and this class turns that snap into a move back */
+.gantt-task-bar.reverting,
+.gantt-milestone.reverting {
+  transition: transform var(--gantt-transition-normal),
+    width var(--gantt-transition-normal),
+    background var(--gantt-transition-fast),
+    box-shadow var(--gantt-transition-normal);
+}
+
+.gantt-task-bar.reverting .gantt-progress-fill,
+.gantt-task-bar.reverting .gantt-progress-handle {
+  transition: width var(--gantt-transition-normal),
+    left var(--gantt-transition-normal);
 }
 
 /* Narrow bars: hide the resize handles (the whole bar is the move handle) */
@@ -739,7 +770,8 @@
   top: 0;
   left: 0;
   bottom: 0;
-  background: var(--gantt-progress-bg);
+  /* Derived from the bar color when there is one, so a colored bar never mixes in the theme gray */
+  background: var(--gantt-progress-color, var(--gantt-progress-bg));
   border-radius: 6px 0 0 6px;
   pointer-events: none;
 }
@@ -805,7 +837,7 @@
   flex-shrink: 0;
   width: 16px;
   height: 16px;
-  background: var(--gantt-milestone-bg);
+  background: var(--gantt-bar-color, var(--gantt-milestone-bg));
   border-radius: 3px;
   transform: rotate(45deg);
   box-shadow: var(--gantt-bar-shadow);
@@ -814,7 +846,7 @@
 }
 
 .gantt-milestone:hover .gantt-milestone-diamond {
-  background: var(--gantt-milestone-bg-hover);
+  background: var(--gantt-bar-color-hover, var(--gantt-milestone-bg-hover));
   box-shadow: var(--gantt-bar-shadow-hover);
 }
 
@@ -869,6 +901,22 @@
     opacity: 1;
     transform: translateX(-50%) translateY(0);
   }
+}
+
+/* Hover tooltip - the same shell, stacked lines instead of one live value */
+.gantt-bar-tooltip-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.gantt-tooltip-name {
+  font-weight: 600;
+}
+
+.gantt-tooltip-meta {
+  opacity: 0.75;
 }
 
 .gantt-bar-tooltip::after {

--- a/src/components/GanttBar.tsx
+++ b/src/components/GanttBar.tsx
@@ -9,28 +9,60 @@ import {
 } from "constants/gantt";
 import { useGanttBarDrag, DragMode } from "hooks/useGanttBarDrag";
 import { useGanttProgressDrag } from "hooks/useGanttProgressDrag";
-import { useRef, useState, useCallback } from "react";
+import { CSSProperties, useRef, useState, useCallback } from "react";
 import { useGanttStore } from "stores/context";
-import { isMilestoneTask, Task, TaskTransformed } from "types/task";
+import { GanttBarOptions, GanttTooltipReason } from "types/gantt";
+import { isMilestoneTask, resolveTaskColors, TaskTransformed } from "types/task";
+import dayjs from "utils/dayjs";
 
 interface GanttBarProps {
   currentTask: TaskTransformed;
-  onTasksChange?: (updatedTasks: Task[]) => void;
+  options?: GanttBarOptions;
+}
+
+/** No options at all is the plain chart - one shared object keeps the default identity stable */
+const NO_OPTIONS: GanttBarOptions = {};
+
+/** Human duration for the default hover tooltip */
+function formatDuration(durationMs: number): string {
+  const hours = Math.max(0, Math.round(durationMs / 3_600_000));
+  return hours < 24 ? `${hours}h` : `${Math.round(hours / 24)}d`;
 }
 
 export default function GanttBar({
   currentTask,
-  onTasksChange,
+  options = NO_OPTIONS,
 }: GanttBarProps) {
+  const {
+    onTasksChange,
+    onBeforeTaskChange,
+    onTaskClick,
+    onTaskDoubleClick,
+    renderBar,
+    renderTooltip,
+    showTooltip = true,
+  } = options;
+
   const barRef = useRef<HTMLDivElement>(null);
-  const { onPointerDown, dragMode } = useGanttBarDrag(currentTask, onTasksChange);
+  const { onPointerDown, dragMode, consumeDragClick } = useGanttBarDrag(
+    currentTask,
+    { onTasksChange, onBeforeTaskChange }
+  );
   const [cursor, setCursor] = useState<"grab" | "ew-resize">("grab");
+  const [hovered, setHovered] = useState(false);
 
   // Read the drag offset
   const liveOffset = useGanttStore((store) => store.dragOffsets[currentTask.id]);
   const isDragging = useGanttStore((store) => store.currentTask?.id === currentTask.id);
   const selectedScale = useGanttStore((store) => store.selectedScale);
-  
+  const isSelected = useGanttStore(
+    (store) => store.selectedTaskId === currentTask.id
+  );
+  // Set while a vetoed change animates back to where the gesture started
+  const isReverting = useGanttStore((store) =>
+    store.revertingIds.includes(currentTask.id)
+  );
+
   const offsetX = liveOffset?.offsetX ?? 0;
   const offsetWidth = liveOffset?.offsetWidth ?? 0;
 
@@ -47,7 +79,10 @@ export default function GanttBar({
 
   // Progress (milestones have none)
   const { onProgressPointerDown, progress, isDraggingProgress } =
-    useGanttProgressDrag(currentTask, barRef, onTasksChange);
+    useGanttProgressDrag(currentTask, barRef, {
+      onTasksChange,
+      onBeforeTaskChange,
+    });
   const showProgress = !isMilestone && progress !== null;
   // A summary row's progress is rolled up from its children, so it is not draggable
   const showProgressHandle = showProgress && !currentTask.isSummary;
@@ -80,6 +115,16 @@ export default function GanttBar({
     [isMilestone, currentTask.isSummary]
   );
 
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // The click that closes a drag is the end of that gesture, not a selection
+    if (consumeDragClick()) return;
+    onTaskClick?.(currentTask, e);
+  };
+
+  const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    onTaskDoubleClick?.(currentTask, e);
+  };
+
   // Build the tooltip text (shown differently per mode)
   const format = DATE_FORMATS[selectedScale];
   const getTooltipText = (mode: DragMode | null) => {
@@ -101,19 +146,147 @@ export default function GanttBar({
     }
   };
 
+  // What the tooltip is for, most specific first - a gesture in progress beats a hover
+  const tooltipReason: GanttTooltipReason | null = !showTooltip
+    ? null
+    : isDraggingProgress
+      ? "progress"
+      : isDragging && liveOffset
+        ? dragMode === "left" || dragMode === "right"
+          ? "resize"
+          : "move"
+        : hovered
+          ? "hover"
+          : null;
+
+  const renderTooltipNode = () => {
+    if (!tooltipReason) return null;
+
+    const isGesture = tooltipReason !== "hover";
+    const startDate =
+      isGesture && liveOffset
+        ? liveOffset.offsetStartDate
+        : dayjs(currentTask.startDate);
+    const endDate = isMilestone
+      ? startDate
+      : isGesture && liveOffset
+        ? liveOffset.offsetEndDate
+        : dayjs(currentTask.endDate);
+
+    if (renderTooltip) {
+      return renderTooltip({
+        task: currentTask,
+        reason: tooltipReason,
+        startDate,
+        endDate,
+        durationMs: endDate.valueOf() - startDate.valueOf(),
+        progress,
+        scale: selectedScale,
+      });
+    }
+
+    // Gesture tooltips are a single live line; the hover one is the task's summary
+    if (tooltipReason === "progress") {
+      return (
+        <div className="gantt-bar-tooltip" role="status" aria-live="polite">
+          {progress}%
+        </div>
+      );
+    }
+
+    if (isGesture) {
+      return (
+        <div className="gantt-bar-tooltip" role="status" aria-live="polite">
+          {getTooltipText(dragMode)}
+        </div>
+      );
+    }
+
+    return (
+      <div className="gantt-bar-tooltip gantt-bar-tooltip-detail" role="tooltip">
+        <span className="gantt-tooltip-name">{currentTask.name}</span>
+        <span className="gantt-tooltip-meta">
+          {isMilestone
+            ? startDate.format(format)
+            : `${startDate.format(format)} → ${endDate.format(format)}`}
+        </span>
+        {!isMilestone && (
+          <span className="gantt-tooltip-meta">
+            {formatDuration(endDate.valueOf() - startDate.valueOf())}
+            {progress !== null ? ` · ${progress}%` : ""}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const colorVars = resolveTaskColors(currentTask.color) as CSSProperties;
+
+  const barStyle: CSSProperties = isMilestone
+    ? {
+        transform: `translateX(${finalLeft - MILESTONE_HALF_DIAGONAL}px)`,
+        height: NODE_HEIGHT / 2,
+        cursor: isDragging ? "grabbing" : "grab",
+        ...colorVars,
+      }
+    : {
+        transform: `translateX(${finalLeft}px)`,
+        width: finalWidth,
+        height: NODE_HEIGHT / 2,
+        cursor: isDragging ? "grabbing" : cursor,
+        ...colorVars,
+      };
+
+  // A replacement owns the whole node, tooltip included - it gets the layout it needs plus
+  // the handlers, so drag, click and double-click keep working when they are spread on
+  if (renderBar) {
+    return (
+      <>
+        {renderBar({
+          task: currentTask,
+          left: finalLeft,
+          width: finalWidth,
+          height: NODE_HEIGHT / 2,
+          progress,
+          scale: selectedScale,
+          isMilestone,
+          isSummary: Boolean(currentTask.isSummary),
+          isDragging,
+          isSelected,
+          barProps: {
+            style: barStyle,
+            onPointerDown,
+            onClick: handleClick,
+            onDoubleClick: handleDoubleClick,
+          },
+        })}
+      </>
+    );
+  }
+
+  // Appended after the existing classes so a plain task still reads exactly as before
+  const extraClasses = [
+    isSelected ? "selected" : "",
+    isReverting ? "reverting" : "",
+    currentTask.className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const suffix = extraClasses ? ` ${extraClasses}` : "";
+
   // Milestone: a diamond at the single startDate point, with a label to its right
   if (isMilestone) {
     return (
       <div
         ref={barRef}
         id={`task-${currentTask.id}`}
-        className={`gantt-milestone${isDragging ? " dragging" : ""}`}
+        className={`gantt-milestone${isDragging ? " dragging" : ""}${suffix}`}
         onPointerDown={onPointerDown}
-        style={{
-          transform: `translateX(${finalLeft - MILESTONE_HALF_DIAGONAL}px)`,
-          height: NODE_HEIGHT / 2,
-          cursor: isDragging ? "grabbing" : "grab",
-        }}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={barStyle}
         role="button"
         tabIndex={0}
         aria-label={`Milestone: ${currentTask.name}`}
@@ -121,12 +294,7 @@ export default function GanttBar({
         <div className="gantt-milestone-diamond" />
         <span className="gantt-milestone-name">{currentTask.name}</span>
 
-        {/* Tooltip while dragging */}
-        {isDragging && liveOffset && (
-          <div className="gantt-bar-tooltip" role="status" aria-live="polite">
-            {getTooltipText(dragMode)}
-          </div>
-        )}
+        {renderTooltipNode()}
       </div>
     );
   }
@@ -137,16 +305,17 @@ export default function GanttBar({
       id={`task-${currentTask.id}`}
       className={`gantt-task-bar${isDragging ? " dragging" : ""}${
         labelOutside ? " compact" : ""
-      }${currentTask.isSummary ? " summary" : ""}`}
+      }${currentTask.isSummary ? " summary" : ""}${suffix}`}
       onPointerDown={onPointerDown}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onMouseMove={handleMouseMove}
-      onMouseLeave={() => setCursor("grab")}
-      style={{
-        transform: `translateX(${finalLeft}px)`,
-        width: finalWidth,
-        height: NODE_HEIGHT / 2,
-        cursor: isDragging ? "grabbing" : cursor,
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => {
+        setCursor("grab");
+        setHovered(false);
       }}
+      style={barStyle}
       role="button"
       tabIndex={0}
       aria-label={
@@ -186,19 +355,7 @@ export default function GanttBar({
         {currentTask.name}
       </span>
 
-      {/* Tooltip while dragging */}
-      {isDragging && liveOffset && (
-        <div className="gantt-bar-tooltip" role="status" aria-live="polite">
-          {getTooltipText(dragMode)}
-        </div>
-      )}
-
-      {/* Tooltip while dragging progress */}
-      {isDraggingProgress && (
-        <div className="gantt-bar-tooltip" role="status" aria-live="polite">
-          {progress}%
-        </div>
-      )}
+      {renderTooltipNode()}
     </div>
   );
 }

--- a/src/components/GanttChartHeader.tsx
+++ b/src/components/GanttChartHeader.tsx
@@ -1,7 +1,11 @@
 import { GANTT_SCALE_CONFIG } from "constants/gantt";
 import { useGanttColumnVirtualization } from "hooks/useGanttVirtualization";
-import React, { useMemo } from "react";
-import { GanttBottomRowCell, GanttScaleKey } from "types/gantt";
+import React, { Fragment, useMemo } from "react";
+import {
+  GanttBottomRowCell,
+  GanttHeaderCellRenderer,
+  GanttScaleKey,
+} from "types/gantt";
 import { mergeHeaderGroups } from "utils/headerUtils";
 import { createTopHeaderGroups } from "utils/timeline";
 
@@ -11,6 +15,8 @@ interface GanttChartHeaderProps {
   width: number;
   /** Scroll container used to virtualize the bottom time cells (pinning the top group labels is done with CSS sticky) */
   scrollRef: React.RefObject<HTMLDivElement | null>;
+  /** Replaces a header cell wholesale - both rows go through it */
+  renderHeaderCell?: GanttHeaderCellRenderer;
 }
 
 /**
@@ -22,6 +28,7 @@ function GanttChartHeader({
   selectedScale,
   width,
   scrollRef,
+  renderHeaderCell,
 }: GanttChartHeaderProps) {
   const config = GANTT_SCALE_CONFIG[selectedScale];
 
@@ -47,15 +54,29 @@ function GanttChartHeader({
         {/* Top header groups */}
         <div className="gantt-top-header">
           <div className="gantt-top-groups">
-            {topGroups.map((group, idx) => (
-              <div
-                key={`${group.label}-${idx}`}
-                className="gantt-top-group"
-                style={{ width: `${group.widthPx}px` }}
-              >
-                <p className="gantt-top-group-label">{group.label}</p>
-              </div>
-            ))}
+            {topGroups.map((group, idx) => {
+              const cellProps = {
+                className: "gantt-top-group",
+                style: { width: `${group.widthPx}px` },
+              };
+
+              return renderHeaderCell ? (
+                <Fragment key={`${group.label}-${idx}`}>
+                  {renderHeaderCell({
+                    row: "top",
+                    date: group.startDate,
+                    label: group.label,
+                    width: group.widthPx,
+                    scale: selectedScale,
+                    cellProps,
+                  })}
+                </Fragment>
+              ) : (
+                <div key={`${group.label}-${idx}`} {...cellProps}>
+                  <p className="gantt-top-group-label">{group.label}</p>
+                </div>
+              );
+            })}
           </div>
         </div>
 
@@ -68,13 +89,24 @@ function GanttChartHeader({
             if (!cell) return null;
 
             const tickLabel = config.formatTickLabel?.(cell.startDate) || "";
+            const cellProps = {
+              className: "gantt-bottom-cell",
+              style: { width: `${virtualCell.size}px` },
+            };
 
-            return (
-              <div
-                key={`bottom-${virtualCell.index}`}
-                className="gantt-bottom-cell"
-                style={{ width: `${virtualCell.size}px` }}
-              >
+            return renderHeaderCell ? (
+              <Fragment key={`bottom-${virtualCell.index}`}>
+                {renderHeaderCell({
+                  row: "bottom",
+                  date: cell.startDate,
+                  label: tickLabel,
+                  width: virtualCell.size,
+                  scale: selectedScale,
+                  cellProps,
+                })}
+              </Fragment>
+            ) : (
+              <div key={`bottom-${virtualCell.index}`} {...cellProps}>
                 {tickLabel}
               </div>
             );

--- a/src/components/GanttTaskGrid.tsx
+++ b/src/components/GanttTaskGrid.tsx
@@ -22,6 +22,10 @@ interface GanttTaskGridProps {
   hierarchy: boolean;
   collapsedIds: Set<string>;
   onToggleCollapse: (taskId: string) => void;
+  /** The selected row, highlighted in step with its bar */
+  selectedTaskId?: string | null;
+  onRowClick?: (task: TaskTransformed, event: React.MouseEvent) => void;
+  onRowDoubleClick?: (task: TaskTransformed, event: React.MouseEvent) => void;
 }
 
 /** Without a render, task[key] is shown as-is */
@@ -57,6 +61,9 @@ export default function GanttTaskGrid({
   hierarchy,
   collapsedIds,
   onToggleCollapse,
+  selectedTaskId,
+  onRowClick,
+  onRowDoubleClick,
 }: GanttTaskGridProps) {
   const clampWidth = (next: number) =>
     Math.min(MAX_GRID_WIDTH, Math.max(MIN_GRID_WIDTH, next));
@@ -120,11 +127,17 @@ export default function GanttTaskGrid({
           return (
             <div
               key={`grid-row-${task.id}`}
-              className={`gantt-grid-row${task.isSummary ? " summary" : ""}`}
+              className={`gantt-grid-row${task.isSummary ? " summary" : ""}${
+                task.id === selectedTaskId ? " selected" : ""
+              }${task.className ? ` ${task.className}` : ""}`}
               style={{
                 height: `${virtualRow.size}px`,
                 transform: `translateY(${virtualRow.start}px)`,
               }}
+              onClick={onRowClick && ((e) => onRowClick(task, e))}
+              onDoubleClick={
+                onRowDoubleClick && ((e) => onRowDoubleClick(task, e))
+              }
             >
               {columns.map((column, index) => (
                 <div
@@ -146,7 +159,11 @@ export default function GanttTaskGrid({
                         className={`gantt-grid-expander${
                           collapsed ? "" : " open"
                         }`}
-                        onClick={() => onToggleCollapse(task.id)}
+                        onClick={(e) => {
+                          // Expanding a row is not selecting it
+                          e.stopPropagation();
+                          onToggleCollapse(task.id);
+                        }}
                         aria-expanded={!collapsed}
                         aria-label={`${collapsed ? "Expand" : "Collapse"} ${task.name}`}
                       >

--- a/src/hooks/useGanttBarDrag.ts
+++ b/src/hooks/useGanttBarDrag.ts
@@ -6,13 +6,27 @@ import {
 import { Dayjs } from "dayjs";
 import { useRef } from "react";
 import { useGanttStore, useGanttStoreApi } from "stores/context";
-import { GanttDragOffset, GanttScaleKey } from "types/gantt";
+import {
+  GanttBeforeChangeHandler,
+  GanttDragOffset,
+  GanttScaleKey,
+} from "types/gantt";
 import { isMilestoneTask, Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
+import {
+  buildTaskChange,
+  mutationKey,
+  REVERT_DURATION_MS,
+} from "utils/mutation";
 import { shiftByDragSteps } from "utils/timeline";
 import { collectSubtreeIds } from "utils/tree";
 
 export type DragMode = "bar" | "left" | "right";
+
+export interface GanttBarDragOptions {
+  onTasksChange?: (updatedTasks: Task[]) => void;
+  onBeforeTaskChange?: GanttBeforeChangeHandler;
+}
 
 interface DragContext {
   mode: DragMode;
@@ -30,6 +44,8 @@ interface DragContext {
   taskIds: string[];
   /** Dates the moving tasks had when the drag started */
   initialDates: Map<string, { start: Dayjs; end: Dayjs }>;
+  /** Claimed on the first movement - null while the gesture has not moved the bar yet */
+  gateToken: number | null;
 }
 
 /**
@@ -37,13 +53,15 @@ interface DragContext {
  */
 export function useGanttBarDrag(
   task: TaskTransformed,
-  onTasksChange?: (updatedTasks: Task[]) => void
+  options: GanttBarDragOptions = {}
 ) {
   const storeApi = useGanttStoreApi();
   const dragContextRef = useRef<DragContext | null>(null);
   const dragModeRef = useRef<DragMode | null>(null);
-  const onTasksChangeRef = useRef(onTasksChange);
-  onTasksChangeRef.current = onTasksChange;
+  // The pointerup that ends a drag is followed by a click - this tells the two apart
+  const movedRef = useRef(false);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   const selectedScale = useGanttStore((s) => s.selectedScale);
   const { basePxPerDragStep } = GANTT_SCALE_CONFIG[selectedScale];
@@ -74,6 +92,7 @@ export function useGanttBarDrag(
 
     const mode = detectDragMode(e);
     dragModeRef.current = mode;
+    movedRef.current = false;
 
     // Dragging a summary bar moves its whole subtree by the same delta
     const rawTasks = storeApi.getState().rawTasks;
@@ -108,6 +127,7 @@ export function useGanttBarDrag(
       taskId: task.id,
       taskIds,
       initialDates,
+      gateToken: null,
     };
 
     storeApi.getState().setCurrentTask(task);
@@ -131,6 +151,15 @@ export function useGanttBarDrag(
 
       if (steps === ctx.dragSteps) return;
       ctx.dragSteps = steps;
+      movedRef.current = true;
+
+      // The lane is claimed the moment the bar actually moves, so a veto still awaiting an
+      // answer for an earlier gesture on this bar knows it has been superseded
+      if (ctx.gateToken === null) {
+        ctx.gateToken = storeApi
+          .getState()
+          .mutationGate.begin(mutationKey("move", ctx.taskId));
+      }
 
       const draggedPx = steps * ctx.basePxPerDragStep;
       const shift = (date: Dayjs) => shiftByDragSteps(date, steps, ctx.scaleKey);
@@ -228,7 +257,7 @@ export function useGanttBarDrag(
       }
 
       const currentRawTasks = storeApi.getState().rawTasks;
-      const commit = (date: string) =>
+      const shiftDate = (date: string) =>
         shiftByDragSteps(dayjs(date), ctx.dragSteps, ctx.scaleKey).toISOString();
 
       // However many tasks moved, there is one updated array - onTasksChange fires once
@@ -240,20 +269,20 @@ export function useGanttBarDrag(
           case "bar":
             return {
               ...t,
-              startDate: commit(t.startDate),
-              endDate: commit(t.endDate),
+              startDate: shiftDate(t.startDate),
+              endDate: shiftDate(t.endDate),
             };
 
           case "left":
             return {
               ...t,
-              startDate: commit(t.startDate),
+              startDate: shiftDate(t.startDate),
             };
 
           case "right":
             return {
               ...t,
-              endDate: commit(t.endDate),
+              endDate: shiftDate(t.endDate),
             };
 
           default:
@@ -261,15 +290,67 @@ export function useGanttBarDrag(
         }
       });
 
-      storeApi.getState().setRawTasks(updatedTasks);
-      onTasksChangeRef.current?.(updatedTasks);
+      const change = buildTaskChange({
+        type: ctx.mode === "bar" ? "move" : "resize",
+        taskId: ctx.taskId,
+        changedIds: ctx.taskIds,
+        previous: currentRawTasks,
+        next: updatedTasks,
+        edge:
+          ctx.mode === "left" ? "start" : ctx.mode === "right" ? "end" : undefined,
+      });
+
+      // Written against the tasks as they are at commit time, not against the snapshot
+      // taken at drop - another bar may have committed while a veto was in flight
+      const commit = () => {
+        const edited = new Map(change.changedTasks.map((t) => [t.id, t]));
+        const merged = storeApi
+          .getState()
+          .rawTasks.map((t) => edited.get(t.id) ?? t);
+
+        storeApi.getState().setRawTasks(merged);
+        optionsRef.current.onTasksChange?.(merged);
+      };
+
+      // Nothing was written, so dropping the drag offsets puts the bar back where it
+      // started - the reverting flag is only there to make that a transition
+      const rollback = () => {
+        const state = storeApi.getState();
+        state.beginRevert(ctx.taskIds);
+        state.clearDragOffsets(ctx.taskIds);
+        setTimeout(
+          () => storeApi.getState().endRevert(ctx.taskIds),
+          REVERT_DURATION_MS
+        );
+      };
 
       // dragOffset is deliberately not cleared here - clearing it before the new
       // transformedTasks are computed makes the bar flick back to its old position for
       // one frame. Gantt's timeline recomputation effect clears it along with the new positions.
+      // While a before-handler is pending it is what holds the bar at the dropped position.
       dragContextRef.current = null;
       dragModeRef.current = null;
       storeApi.getState().setCurrentTask(null);
+
+      const onBeforeTaskChange = optionsRef.current.onBeforeTaskChange;
+      if (!onBeforeTaskChange || ctx.gateToken === null) {
+        commit();
+        return;
+      }
+
+      void storeApi
+        .getState()
+        .mutationGate.settle(
+          mutationKey("move", ctx.taskId),
+          ctx.gateToken,
+          onBeforeTaskChange,
+          change
+        )
+        .then((outcome) => {
+          if (outcome === "commit") commit();
+          else if (outcome === "rollback") rollback();
+          // 'stale' - a newer gesture owns this bar, so this answer is dropped
+        });
     };
 
     document.addEventListener("pointermove", handlePointerMove);
@@ -277,8 +358,21 @@ export function useGanttBarDrag(
     document.addEventListener("pointercancel", handlePointerCancel);
   };
 
-  return { 
-    onPointerDown, 
-    dragMode: dragModeRef.current 
+  /**
+   * Reports whether the click now arriving is the tail of a drag, and clears the flag
+   *
+   * The browser fires a click after the pointerup that ended a gesture; that click is the
+   * end of the drag, not a selection.
+   */
+  const consumeDragClick = (): boolean => {
+    if (!movedRef.current) return false;
+    movedRef.current = false;
+    return true;
+  };
+
+  return {
+    onPointerDown,
+    dragMode: dragModeRef.current,
+    consumeDragClick,
   };
 }

--- a/src/hooks/useGanttProgressDrag.ts
+++ b/src/hooks/useGanttProgressDrag.ts
@@ -1,6 +1,24 @@
 import React, { useRef, useState } from "react";
 import { useGanttStoreApi } from "stores/context";
+import { GanttBeforeChangeHandler } from "types/gantt";
 import { normalizeProgress, Task, TaskTransformed } from "types/task";
+import {
+  buildTaskChange,
+  mutationKey,
+  REVERT_DURATION_MS,
+} from "utils/mutation";
+
+export interface GanttProgressDragOptions {
+  onTasksChange?: (updatedTasks: Task[]) => void;
+  onBeforeTaskChange?: GanttBeforeChangeHandler;
+}
+
+/** The value on screen while the gesture runs, and after it while a veto is pending */
+interface LiveProgress {
+  percent: number;
+  /** The pointer is up and the before-handler has not answered yet */
+  pending: boolean;
+}
 
 /**
  * Progress handle drag hook
@@ -9,10 +27,10 @@ import { normalizeProgress, Task, TaskTransformed } from "types/task";
 export function useGanttProgressDrag(
   task: TaskTransformed,
   barRef: React.RefObject<HTMLDivElement | null>,
-  onTasksChange?: (updatedTasks: Task[]) => void
+  options: GanttProgressDragOptions = {}
 ) {
   const storeApi = useGanttStoreApi();
-  const [liveProgress, setLiveProgress] = useState<number | null>(null);
+  const [live, setLive] = useState<LiveProgress | null>(null);
   const liveProgressRef = useRef<number | null>(null);
 
   const percentFromPointer = (clientX: number): number | null => {
@@ -26,17 +44,30 @@ export function useGanttProgressDrag(
     return Math.round(Math.min(1, Math.max(0, ratio)) * 100);
   };
 
+  // The callbacks come from the render the gesture started in - a gesture is short enough
+  // that a latest-ref would only add a stale-read hazard
+  const { onTasksChange, onBeforeTaskChange } = options;
+
   const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
     // Blocked so it does not overlap with the bar move drag
     e.stopPropagation();
     e.preventDefault();
 
+    // A fresh gesture supersedes a veto still pending on this bar's progress
+    let gateToken: number | null = null;
+
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const percent = percentFromPointer(moveEvent.clientX);
       if (percent === null) return;
 
+      if (gateToken === null) {
+        gateToken = storeApi
+          .getState()
+          .mutationGate.begin(mutationKey("progress", task.id));
+      }
+
       liveProgressRef.current = percent;
-      setLiveProgress(percent);
+      setLive({ percent, pending: false });
     };
 
     const handlePointerUp = () => {
@@ -46,18 +77,67 @@ export function useGanttProgressDrag(
 
       const percent = liveProgressRef.current;
       liveProgressRef.current = null;
-      setLiveProgress(null);
 
-      if (percent === null) return;
+      if (percent === null) {
+        setLive(null);
+        return;
+      }
 
-      const updatedTasks = storeApi
-        .getState()
-        .rawTasks.map((t) =>
-          t.id === task.id ? { ...t, progress: percent } : t
+      const previous = storeApi.getState().rawTasks;
+      const next = previous.map((t) =>
+        t.id === task.id ? { ...t, progress: percent } : t
+      );
+      const change = buildTaskChange({
+        type: "progress",
+        taskId: task.id,
+        changedIds: [task.id],
+        previous,
+        next,
+      });
+
+      const commit = () => {
+        const edited = change.changedTasks[0];
+        const merged = storeApi
+          .getState()
+          .rawTasks.map((t) => (t.id === edited?.id ? edited : t));
+
+        storeApi.getState().setRawTasks(merged);
+        setLive(null);
+        onTasksChange?.(merged);
+      };
+
+      // Nothing was written, so dropping the preview shows the stored progress again
+      const rollback = () => {
+        const state = storeApi.getState();
+        state.beginRevert([task.id]);
+        setLive(null);
+        setTimeout(
+          () => storeApi.getState().endRevert([task.id]),
+          REVERT_DURATION_MS
         );
+      };
 
-      storeApi.getState().setRawTasks(updatedTasks);
-      onTasksChange?.(updatedTasks);
+      if (!onBeforeTaskChange || gateToken === null) {
+        commit();
+        return;
+      }
+
+      // The fill stays where the user let go while the handler runs
+      setLive({ percent, pending: true });
+
+      void storeApi
+        .getState()
+        .mutationGate.settle(
+          mutationKey("progress", task.id),
+          gateToken,
+          onBeforeTaskChange,
+          change
+        )
+        .then((outcome) => {
+          if (outcome === "commit") commit();
+          else if (outcome === "rollback") rollback();
+          // 'stale' - a newer gesture owns this handle, so this answer is dropped
+        });
     };
 
     document.addEventListener("pointermove", handlePointerMove);
@@ -67,7 +147,7 @@ export function useGanttProgressDrag(
 
   return {
     onProgressPointerDown: onPointerDown,
-    progress: liveProgress ?? normalizeProgress(task.progress),
-    isDraggingProgress: liveProgress !== null,
+    progress: live?.percent ?? normalizeProgress(task.progress),
+    isDraggingProgress: live !== null && !live.pending,
   };
 }

--- a/src/hooks/useGanttSelectors.ts
+++ b/src/hooks/useGanttSelectors.ts
@@ -17,6 +17,7 @@ export function useGanttSelectors() {
       transformedTasks: state.transformedTasks,
       bottomRowCells: state.bottomRowCells,
       selectedScale: state.selectedScale,
+      selectedTaskId: state.selectedTaskId,
 
       // Actions
       setRawTasks: state.setRawTasks,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,4 +17,18 @@ export type {
   TaskType,
   TaskTransformed,
 } from './types/task';
-export type { GanttColumn, GanttScaleKey, GanttTheme } from './types/gantt';
+export type {
+  GanttColumn,
+  GanttScaleKey,
+  GanttTheme,
+  GanttChangeType,
+  GanttTaskChange,
+  GanttBeforeChangeHandler,
+  GanttBarRenderProps,
+  GanttBarRenderer,
+  GanttTooltipReason,
+  GanttTooltipRenderProps,
+  GanttTooltipRenderer,
+  GanttHeaderCellRenderProps,
+  GanttHeaderCellRenderer,
+} from './types/gantt';

--- a/src/pages/Gantt.tsx
+++ b/src/pages/Gantt.tsx
@@ -19,7 +19,7 @@ import { useGanttSelectors } from "hooks/useGanttSelectors";
 import { GanttHandle, useGanttScrollApi } from "hooks/useGanttScrollApi";
 import { useGanttVirtualization } from "hooks/useGanttVirtualization";
 import { useResolvedTheme } from "hooks/useResolvedTheme";
-import { GanttStoreContext } from "stores/context";
+import { GanttStoreContext, useGanttStoreApi } from "stores/context";
 import {
   createGanttStore,
   DEFAULT_SCALE_STORAGE_KEY,
@@ -31,12 +31,16 @@ import {
   NODE_HEIGHT,
 } from "constants/gantt";
 import {
+  GanttBarRenderer,
+  GanttBeforeChangeHandler,
   GanttBottomRowCell,
   GanttColumn,
+  GanttHeaderCellRenderer,
   GanttScaleKey,
   GanttTheme,
+  GanttTooltipRenderer,
 } from "types/gantt";
-import { Task } from "types/task";
+import { Task, TaskTransformed } from "types/task";
 import dayjs from "utils/dayjs";
 import {
   calculateDateOffsetPx,
@@ -135,6 +139,41 @@ export interface GanttProps {
   defaultCollapsedIds?: string[];
   /** Called whenever the collapsed state changes - in controlled and uncontrolled mode alike */
   onCollapsedChange?: (collapsedIds: string[]) => void;
+  /** Fires when a bar or a task-list row is clicked (not after a drag) */
+  onTaskClick?: (task: TaskTransformed, event: React.MouseEvent) => void;
+  /** Fires on a double click. The two clicks that make it up still fire `onTaskClick` */
+  onTaskDoubleClick?: (task: TaskTransformed, event: React.MouseEvent) => void;
+  /**
+   * Fires when the selection changes - null when the empty timeline is clicked
+   *
+   * Passing it turns selection on: the selected bar and its task-list row are highlighted.
+   */
+  onTaskSelect?: (task: TaskTransformed | null) => void;
+  /**
+   * Whether clicking selects a row
+   *
+   * Omitted, selection is on only when `onTaskSelect` is given - pass `true` for the
+   * highlight without a callback, `false` to turn it off entirely.
+   */
+  selectable?: boolean;
+  /**
+   * Runs before a move, resize or progress change is written, and can cancel it
+   *
+   * Returning `false`, a promise resolving to `false`, or a rejected promise rolls the bar
+   * back to where the gesture started. Anything else commits and `onTasksChange` follows.
+   * While the promise is pending the bar stays where it was dropped, so a server round trip
+   * never blocks the UI - and if the user starts another gesture on that bar in the
+   * meantime, the late answer is dropped rather than fighting the newer one.
+   */
+  onBeforeTaskChange?: GanttBeforeChangeHandler;
+  /** Replaces the default bar node entirely - gets the task, its layout, and the handlers to spread */
+  renderBar?: GanttBarRenderer;
+  /** Replaces the default tooltip node entirely - used for hover and for drag alike */
+  renderTooltip?: GanttTooltipRenderer;
+  /** Replaces a timeline header cell entirely - both header rows go through it */
+  renderHeaderCell?: GanttHeaderCellRenderer;
+  /** Hover and drag tooltips (default true) - `false` suppresses both */
+  showTooltip?: boolean;
 }
 
 /**
@@ -178,14 +217,25 @@ function GanttChart({
   collapsedIds,
   defaultCollapsedIds,
   onCollapsedChange,
+  onTaskClick,
+  onTaskDoubleClick,
+  onTaskSelect,
+  selectable,
+  onBeforeTaskChange,
+  renderBar,
+  renderTooltip,
+  renderHeaderCell,
+  showTooltip,
   forwardedRef,
 }: GanttProps & { forwardedRef: React.ForwardedRef<GanttHandle> }) {
+  const storeApi = useGanttStoreApi();
   // Store state and actions
   const {
     rawTasks,
     transformedTasks,
     bottomRowCells,
     selectedScale,
+    selectedTaskId,
     setRawTasks,
     setTransformedTasks,
     setBottomRowCells,
@@ -231,6 +281,61 @@ function GanttChart({
       onCollapsedChange?.(next);
     },
     [collapsed, collapsedIds, onCollapsedChange]
+  );
+
+  // ===== Selection =====
+  // Like showTaskList/columns: without an explicit flag, the callback turns the feature on
+  const selectionEnabled = selectable ?? onTaskSelect !== undefined;
+
+  // One place for both panes, so a bar and its row can never disagree about what is selected
+  const selectTask = useCallback(
+    (task: TaskTransformed | null) => {
+      if (!selectionEnabled) return;
+
+      const nextId = task?.id ?? null;
+      if (storeApi.getState().selectedTaskId === nextId) return;
+
+      storeApi.getState().setSelectedTaskId(nextId);
+      onTaskSelect?.(task);
+    },
+    [selectionEnabled, onTaskSelect, storeApi]
+  );
+
+  const handleTaskClick = useCallback(
+    (task: TaskTransformed, event: React.MouseEvent) => {
+      onTaskClick?.(task, event);
+      selectTask(task);
+    },
+    [onTaskClick, selectTask]
+  );
+
+  const handleTaskDoubleClick = useCallback(
+    (task: TaskTransformed, event: React.MouseEvent) => {
+      onTaskDoubleClick?.(task, event);
+    },
+    [onTaskDoubleClick]
+  );
+
+  // Everything the bars need from props, in one object so the row map stays readable
+  const barOptions = useMemo(
+    () => ({
+      onTasksChange,
+      onBeforeTaskChange,
+      onTaskClick: handleTaskClick,
+      onTaskDoubleClick: handleTaskDoubleClick,
+      renderBar,
+      renderTooltip,
+      showTooltip,
+    }),
+    [
+      onTasksChange,
+      onBeforeTaskChange,
+      handleTaskClick,
+      handleTaskDoubleClick,
+      renderBar,
+      renderTooltip,
+      showTooltip,
+    ]
   );
 
   // Rows left after hiding collapsed subtrees - the grid and the timeline read the same
@@ -446,6 +551,9 @@ function GanttChart({
                 hierarchy={hierarchy}
                 collapsedIds={collapsedSet}
                 onToggleCollapse={handleToggleCollapse}
+                selectedTaskId={selectedTaskId}
+                onRowClick={handleTaskClick}
+                onRowDoubleClick={handleTaskDoubleClick}
               />
             )}
 
@@ -460,6 +568,7 @@ function GanttChart({
                   selectedScale={selectedScale}
                   width={totalWidth}
                   scrollRef={scrollRef}
+                  renderHeaderCell={renderHeaderCell}
                 />
               </div>
 
@@ -469,6 +578,10 @@ function GanttChart({
                 style={{
                   height: `${rowVirtualizer.getTotalSize()}px`,
                   width: `${totalWidth}px`,
+                }}
+                // Empty timeline clears the selection; a click on a bar has a different target
+                onClick={(event) => {
+                  if (event.target === event.currentTarget) selectTask(null);
                 }}
               >
                 {/* Non-working-day shading */}
@@ -542,10 +655,7 @@ function GanttChart({
                         alignItems: "center",
                       }}
                     >
-                      <GanttBar
-                        currentTask={task}
-                        onTasksChange={onTasksChange}
-                      />
+                      <GanttBar currentTask={task} options={barOptions} />
                     </div>
                   );
                 })}

--- a/src/stores/store.test.ts
+++ b/src/stores/store.test.ts
@@ -149,3 +149,40 @@ describe('per-instance isolation', () => {
     expect(readPersistedScale('gantt-scale-b')).toBe('day');
   });
 });
+
+describe('selection and revert flags', () => {
+  it('keeps the selection identity stable when the same row is clicked twice', () => {
+    expect(store.getState().selectedTaskId).toBeNull();
+
+    store.getState().setSelectedTaskId('a1');
+    const afterFirst = store.getState();
+
+    store.getState().setSelectedTaskId('a1');
+    expect(store.getState()).toBe(afterFirst);
+
+    store.getState().setSelectedTaskId(null);
+    expect(store.getState().selectedTaskId).toBeNull();
+  });
+
+  it('marks a whole subtree as reverting without duplicating ids', () => {
+    store.getState().beginRevert(['a1', 'a2']);
+    store.getState().beginRevert(['a2', 'a3']);
+    expect(store.getState().revertingIds).toEqual(['a1', 'a2', 'a3']);
+
+    store.getState().endRevert(['a2']);
+    expect(store.getState().revertingIds).toEqual(['a1', 'a3']);
+
+    // A clear that removes nothing leaves the state object alone
+    const unchanged = store.getState();
+    store.getState().endRevert(['nope']);
+    expect(store.getState()).toBe(unchanged);
+  });
+
+  it('gives every chart its own pending-mutation gate', () => {
+    const other = createGanttStore('gantt-scale-other');
+
+    expect(store.getState().mutationGate.begin('dates:a1')).toBe(1);
+    expect(store.getState().mutationGate.begin('dates:a1')).toBe(2);
+    expect(other.getState().mutationGate.begin('dates:a1')).toBe(1);
+  });
+});

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -5,6 +5,7 @@ import {
   GanttScaleKey,
 } from "types/gantt";
 import { Task, TaskTransformed } from "types/task";
+import { createMutationGate, MutationGate } from "utils/mutation";
 import { createStore } from "zustand";
 
 /** Default key the scale selection is persisted under for the session */
@@ -39,10 +40,19 @@ export interface GanttState {
   currentTask: TaskTransformed | null;
   dragOffsets: Record<string, GanttDragOffset>;
   transformedTasks: TaskTransformed[];
+  /** The selected row, or null - drives the highlight on the bar and on its grid row */
+  selectedTaskId: string | null;
+  /** Ids whose bar is animating back after a vetoed change */
+  revertingIds: string[];
+  /** Guards before-change handlers that are still in flight (created once, never replaced) */
+  mutationGate: MutationGate;
 
   // Actions
   setSelectedScale: (scale: GanttScaleKey) => void;
   setCurrentTask: (task: TaskTransformed | null) => void;
+  setSelectedTaskId: (taskId: string | null) => void;
+  beginRevert: (ids: string[]) => void;
+  endRevert: (ids: string[]) => void;
   setRawTasks: (rawTasks: Task[]) => void;
   setBottomRowCells: (cells: GanttBottomRowCell[]) => void;
   setTransformedTasks: (tasks: TaskTransformed[]) => void;
@@ -74,8 +84,33 @@ export function createGanttStore(
     selectedScale: "month",
     currentTask: null,
     dragOffsets: {},
+    selectedTaskId: null,
+    revertingIds: [],
+    mutationGate: createMutationGate(),
 
     setCurrentTask: (task) => set({ currentTask: task }),
+
+    setSelectedTaskId: (taskId) => {
+      if (get().selectedTaskId === taskId) return;
+      set({ selectedTaskId: taskId });
+    },
+
+    beginRevert: (ids) =>
+      set((state) => {
+        const next = ids.filter((id) => !state.revertingIds.includes(id));
+        return next.length
+          ? { revertingIds: [...state.revertingIds, ...next] }
+          : state;
+      }),
+
+    endRevert: (ids) =>
+      set((state) => {
+        const remove = new Set(ids);
+        const next = state.revertingIds.filter((id) => !remove.has(id));
+        return next.length === state.revertingIds.length
+          ? state
+          : { revertingIds: next };
+      }),
 
     // Session persistence happens only here - with the persist middleware, every store
     // update would write to sessionStorage synchronously, drag frames included

--- a/src/types/gantt.ts
+++ b/src/types/gantt.ts
@@ -1,6 +1,12 @@
 import { Dayjs } from 'dayjs';
-import type { ReactNode } from 'react';
-import type { TaskTransformed } from './task';
+import type {
+  CSSProperties,
+  MouseEvent as ReactMouseEvent,
+  MouseEventHandler,
+  PointerEventHandler,
+  ReactNode,
+} from 'react';
+import type { Task, TaskTransformed } from './task';
 
 /** Theme type - 'light', 'dark', or 'system' (follows the OS setting) */
 export type GanttTheme = 'light' | 'dark' | 'system';
@@ -53,4 +59,121 @@ export interface GanttDragOffset {
   offsetWidth: number;
   offsetStartDate: Dayjs;
   offsetEndDate: Dayjs;
+}
+
+/** What a gesture is about to write */
+export type GanttChangeType = 'move' | 'resize' | 'progress';
+
+/**
+ * The mutation a finished gesture wants to commit
+ *
+ * Handed to `onBeforeTaskChange` before anything is written, so a host can send it to a
+ * server and answer with a veto.
+ */
+export interface GanttTaskChange {
+  type: GanttChangeType;
+  /** The bar the user grabbed */
+  task: Task;
+  /** Only the tasks this gesture rewrites - dragging a summary bar carries its whole subtree */
+  changedTasks: Task[];
+  /** Those same tasks as they were before the gesture, in the same order */
+  previousTasks: Task[];
+  /** The full array the chart would hand to `onTasksChange` */
+  tasks: Task[];
+  /** Which edge moved - `resize` only */
+  edge?: 'start' | 'end';
+}
+
+/**
+ * Runs before a gesture is committed and can cancel it
+ *
+ * Returning `false`, a promise resolving to `false`, or a rejected promise rolls the bar
+ * back to where it started. Anything else commits. While the promise is pending the bar
+ * stays where it was dropped, so the UI never blocks on the round trip.
+ */
+export type GanttBeforeChangeHandler = (
+  change: GanttTaskChange
+) => boolean | void | Promise<boolean | void>;
+
+/** Props handed to a `renderBar` override */
+export interface GanttBarRenderProps {
+  task: TaskTransformed;
+  /** Left offset from the timeline origin in px, live drag offset included */
+  left: number;
+  /** Rendered bar width in px, live drag offset included */
+  width: number;
+  /** Row height available to the bar in px */
+  height: number;
+  /** Progress 0-100, or null when the task has none */
+  progress: number | null;
+  scale: GanttScaleKey;
+  isMilestone: boolean;
+  isSummary: boolean;
+  isDragging: boolean;
+  isSelected: boolean;
+  /**
+   * Spread onto the root node of the replacement
+   *
+   * Carries the positioning style plus the drag, click and double-click handlers, so a
+   * custom bar keeps behaving like the default one.
+   */
+  barProps: {
+    style: CSSProperties;
+    onPointerDown: PointerEventHandler<HTMLDivElement>;
+    onClick: MouseEventHandler<HTMLDivElement>;
+    onDoubleClick: MouseEventHandler<HTMLDivElement>;
+  };
+}
+
+export type GanttBarRenderer = (props: GanttBarRenderProps) => ReactNode;
+
+/** Why a tooltip is showing */
+export type GanttTooltipReason = 'hover' | 'move' | 'resize' | 'progress';
+
+/** Props handed to a `renderTooltip` override */
+export interface GanttTooltipRenderProps {
+  task: TaskTransformed;
+  reason: GanttTooltipReason;
+  /** Start being previewed - the live drag value while a gesture is running */
+  startDate: Dayjs;
+  /** End being previewed - equal to `startDate` for a milestone */
+  endDate: Dayjs;
+  /** End minus start in milliseconds */
+  durationMs: number;
+  /** Progress 0-100, or null when the task has none */
+  progress: number | null;
+  scale: GanttScaleKey;
+}
+
+export type GanttTooltipRenderer = (
+  props: GanttTooltipRenderProps
+) => ReactNode;
+
+/** Props handed to a `renderHeaderCell` override */
+export interface GanttHeaderCellRenderProps {
+  /** `'top'` is a merged group label, `'bottom'` a single time tick */
+  row: 'top' | 'bottom';
+  date: Dayjs;
+  /** The label the default header would print */
+  label: string;
+  width: number;
+  scale: GanttScaleKey;
+  /** Spread onto the root node of the replacement to keep the header layout intact */
+  cellProps: { className: string; style: CSSProperties };
+}
+
+export type GanttHeaderCellRenderer = (
+  props: GanttHeaderCellRenderProps
+) => ReactNode;
+
+/** Everything a bar needs from the chart's props - passed as one object rather than eight */
+export interface GanttBarOptions {
+  onTasksChange?: (updatedTasks: Task[]) => void;
+  onBeforeTaskChange?: GanttBeforeChangeHandler;
+  onTaskClick?: (task: TaskTransformed, event: ReactMouseEvent) => void;
+  onTaskDoubleClick?: (task: TaskTransformed, event: ReactMouseEvent) => void;
+  renderBar?: GanttBarRenderer;
+  renderTooltip?: GanttTooltipRenderer;
+  /** Hover and drag tooltips, on unless explicitly turned off */
+  showTooltip?: boolean;
 }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -11,11 +11,51 @@ export interface Task {
   type?: TaskType;
   /** Progress 0-100 (%) - omitted means no progress display */
   progress?: number;
+  /**
+   * Bar color - any CSS color value
+   *
+   * The progress fill and the hover shade are derived from it, so one value colors the
+   * whole bar. Omitted, the `--gantt-*` theme tokens decide as before.
+   */
+  color?: string;
+  /** Extra class name put on this task's bar and its task-list row */
+  className?: string;
   dependencies?: TaskDependency[];
 }
 
 export function isMilestoneTask(task: Pick<Task, 'type'>): boolean {
   return task.type === 'milestone';
+}
+
+/**
+ * CSS custom properties a colored bar sets
+ *
+ * Every value is a fallback for a theme token, so an empty object means the CSS
+ * defaults keep deciding - a task without a color renders exactly as before.
+ */
+export interface TaskColorVars {
+  '--gantt-bar-color'?: string;
+  '--gantt-bar-color-hover'?: string;
+  '--gantt-progress-color'?: string;
+}
+
+/**
+ * Resolves a task's color into the variables the stylesheet reads
+ *
+ * Precedence: the task's own `color` wins; a missing or blank one resolves to nothing,
+ * which leaves `--gantt-bar-bg` / `--gantt-progress-bg` (and any host override of them)
+ * in charge. The progress fill and the hover shade are always derived from the bar color
+ * rather than read from a token, so a colored bar never mixes in the theme gray.
+ */
+export function resolveTaskColors(color: string | undefined): TaskColorVars {
+  const base = color?.trim();
+  if (!base) return {};
+
+  return {
+    '--gantt-bar-color': base,
+    '--gantt-bar-color-hover': `color-mix(in srgb, ${base} 86%, #000)`,
+    '--gantt-progress-color': `color-mix(in srgb, ${base} 62%, #000)`,
+  };
 }
 
 /** Normalizes progress into the 0-100 range; null when the value is missing or invalid */

--- a/src/utils/mutation.test.ts
+++ b/src/utils/mutation.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveTaskColors, type Task } from 'types/task';
+import { buildTaskChange, createMutationGate, mutationKey } from './mutation';
+
+const task = (id: string, over: Partial<Task> = {}): Task => ({
+  id,
+  name: id,
+  startDate: '2025-01-02T00:00:00.000Z',
+  endDate: '2025-01-03T00:00:00.000Z',
+  parentId: null,
+  sequence: id,
+  ...over,
+});
+
+const shifted = (source: Task, days: number): Task => ({
+  ...source,
+  startDate: `2025-01-0${2 + days}T00:00:00.000Z`,
+  endDate: `2025-01-0${3 + days}T00:00:00.000Z`,
+});
+
+// A gesture always claims its lane before it can settle - the helper keeps that pairing
+const gestureOn = (
+  gate: ReturnType<typeof createMutationGate>,
+  key: string
+) => {
+  const token = gate.begin(key);
+  return (handler: Parameters<typeof gate.settle>[2]) =>
+    gate.settle(key, token, handler, change);
+};
+
+const previous = [task('a'), task('b'), task('c')];
+const next = [shifted(previous[0], 1), previous[1], shifted(previous[2], 1)];
+const change = buildTaskChange({
+  type: 'move',
+  taskId: 'a',
+  changedIds: ['a', 'c'],
+  previous,
+  next,
+});
+
+describe('buildTaskChange', () => {
+  it('carries only the tasks the gesture rewrites', () => {
+    expect(change.type).toBe('move');
+    expect(change.changedTasks.map((t) => t.id)).toEqual(['a', 'c']);
+    expect(change.tasks).toBe(next);
+    expect(change.edge).toBeUndefined();
+  });
+
+  it('lines previousTasks up with changedTasks index for index', () => {
+    expect(change.previousTasks.map((t) => t.id)).toEqual(['a', 'c']);
+    expect(change.previousTasks[0].startDate).toBe(previous[0].startDate);
+    expect(change.changedTasks[0].startDate).not.toBe(previous[0].startDate);
+  });
+
+  it('reports the grabbed task in its post-change shape', () => {
+    expect(change.task.id).toBe('a');
+    expect(change.task).toBe(next[0]);
+  });
+
+  it('keeps the collected ids in render order, not in subtree-walk order', () => {
+    const walkOrder = buildTaskChange({
+      type: 'move',
+      taskId: 'c',
+      changedIds: ['c', 'a'],
+      previous,
+      next,
+    });
+
+    expect(walkOrder.changedTasks.map((t) => t.id)).toEqual(['a', 'c']);
+  });
+
+  it('records the edge of a resize', () => {
+    const resize = buildTaskChange({
+      type: 'resize',
+      taskId: 'a',
+      changedIds: ['a'],
+      previous,
+      next,
+      edge: 'end',
+    });
+
+    expect(resize.edge).toBe('end');
+    expect(resize.changedTasks).toHaveLength(1);
+  });
+
+  it('drops a changed id that has no previous entry rather than emitting a hole', () => {
+    const added = buildTaskChange({
+      type: 'move',
+      taskId: 'a',
+      changedIds: ['a', 'ghost'],
+      previous,
+      next: [...next, task('ghost')],
+    });
+
+    expect(added.changedTasks.map((t) => t.id)).toEqual(['a', 'ghost']);
+    expect(added.previousTasks.map((t) => t.id)).toEqual(['a']);
+  });
+});
+
+describe('mutationKey', () => {
+  it('puts moves and resizes of one task in the same lane', () => {
+    expect(mutationKey('move', 'a')).toBe(mutationKey('resize', 'a'));
+  });
+
+  it('keeps progress in its own lane, and tasks apart', () => {
+    expect(mutationKey('progress', 'a')).not.toBe(mutationKey('move', 'a'));
+    expect(mutationKey('move', 'a')).not.toBe(mutationKey('move', 'b'));
+  });
+});
+
+describe('createMutationGate', () => {
+  it('commits when the handler returns nothing', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(settle(() => undefined)).resolves.toBe('commit');
+  });
+
+  it('commits on an explicit true', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(settle(() => true)).resolves.toBe('commit');
+  });
+
+  it('rolls back on a synchronous false', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(settle(() => false)).resolves.toBe('rollback');
+  });
+
+  it('rolls back on a promise resolving to false', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(
+      settle(async () => {
+        await Promise.resolve();
+        return false;
+      })
+    ).resolves.toBe('rollback');
+  });
+
+  it('rolls back on a rejected promise - the failed-server case', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(
+      settle(() => Promise.reject(new Error('500 from the API')))
+    ).resolves.toBe('rollback');
+  });
+
+  it('rolls back when the handler throws synchronously', async () => {
+    const gate = createMutationGate();
+    const settle = gestureOn(gate, 'dates:a');
+
+    await expect(
+      settle(() => {
+        throw new Error('bad payload');
+      })
+    ).resolves.toBe('rollback');
+  });
+
+  it('hands the change to the handler untouched', async () => {
+    const gate = createMutationGate();
+    const handler = vi.fn(() => undefined);
+
+    await gestureOn(gate, 'dates:a')(handler);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(change);
+  });
+
+  it('drops a veto whose gesture was superseded while it was pending', async () => {
+    const gate = createMutationGate();
+    let release: (value: boolean) => void = () => {};
+    const pending = new Promise<boolean>((resolve) => {
+      release = resolve;
+    });
+
+    // First gesture: dropped, and its handler has not answered yet
+    const first = gestureOn(gate, 'dates:a')(() => pending);
+
+    // Second gesture on the same bar starts and finishes while that is still in flight
+    const second = gestureOn(gate, 'dates:a')(() => undefined);
+    await expect(second).resolves.toBe('commit');
+
+    // The late veto no longer owns the bar, so its answer is dropped
+    release(false);
+    await expect(first).resolves.toBe('stale');
+  });
+
+  it('drops a superseded gesture even when its handler rejects', async () => {
+    const gate = createMutationGate();
+    let fail: (reason: Error) => void = () => {};
+    const pending = new Promise<boolean>((_, reject) => {
+      fail = reject;
+    });
+
+    const first = gestureOn(gate, 'dates:a')(() => pending);
+    await gestureOn(gate, 'dates:a')(() => undefined);
+
+    fail(new Error('timeout'));
+    await expect(first).resolves.toBe('stale');
+  });
+
+  it('lets an unrelated lane settle normally while another one is pending', async () => {
+    const gate = createMutationGate();
+    const never = new Promise<boolean>(() => {});
+
+    const pendingMove = gestureOn(gate, 'dates:a')(() => never);
+    void pendingMove;
+
+    // A different task, and this task's own progress lane, both answer for themselves
+    await expect(gestureOn(gate, 'dates:b')(() => false)).resolves.toBe(
+      'rollback'
+    );
+    await expect(gestureOn(gate, 'progress:a')(() => false)).resolves.toBe(
+      'rollback'
+    );
+  });
+});
+
+describe('resolveTaskColors', () => {
+  it('leaves the theme tokens in charge when there is no color', () => {
+    expect(resolveTaskColors(undefined)).toEqual({});
+    expect(resolveTaskColors('')).toEqual({});
+    expect(resolveTaskColors('   ')).toEqual({});
+  });
+
+  it("takes the task's own color over the defaults", () => {
+    const vars = resolveTaskColors('#3b82f6');
+
+    expect(vars['--gantt-bar-color']).toBe('#3b82f6');
+  });
+
+  it('derives the fill and the hover shade from the bar color, not from a token', () => {
+    const vars = resolveTaskColors('rebeccapurple');
+
+    expect(vars['--gantt-progress-color']).toContain('rebeccapurple');
+    expect(vars['--gantt-bar-color-hover']).toContain('rebeccapurple');
+    // Darker than the bar, and darker again for the fill
+    expect(vars['--gantt-bar-color-hover']).not.toBe(
+      vars['--gantt-progress-color']
+    );
+  });
+
+  it('passes any CSS color form through untouched', () => {
+    expect(resolveTaskColors('  var(--brand)  ')['--gantt-bar-color']).toBe(
+      'var(--brand)'
+    );
+    expect(
+      resolveTaskColors('rgb(255 0 0 / 50%)')['--gantt-bar-color']
+    ).toBe('rgb(255 0 0 / 50%)');
+  });
+});

--- a/src/utils/mutation.ts
+++ b/src/utils/mutation.ts
@@ -1,0 +1,112 @@
+import {
+  GanttBeforeChangeHandler,
+  GanttChangeType,
+  GanttTaskChange,
+} from 'types/gantt';
+import { Task } from 'types/task';
+
+/** How long a rolled-back bar animates back - matches --gantt-transition-normal */
+export const REVERT_DURATION_MS = 200;
+
+/** What the caller should do once the before-handler has answered */
+export type MutationOutcome = 'commit' | 'rollback' | 'stale';
+
+/**
+ * The gate's key for a gesture
+ *
+ * Moves and resizes both rewrite the dates, so they share a lane and supersede each
+ * other; a progress edit runs in its own lane and leaves a pending date change alone.
+ */
+export function mutationKey(type: GanttChangeType, taskId: string): string {
+  return `${type === 'progress' ? 'progress' : 'dates'}:${taskId}`;
+}
+
+export interface BuildTaskChangeParams {
+  type: GanttChangeType;
+  /** The bar the user grabbed */
+  taskId: string;
+  /** Ids the gesture rewrites - more than one when a summary bar carries its subtree */
+  changedIds: string[];
+  /** The task array as it was before the gesture */
+  previous: Task[];
+  /** The task array the gesture wants to commit */
+  next: Task[];
+  edge?: 'start' | 'end';
+}
+
+/**
+ * Builds the payload handed to `onBeforeTaskChange`
+ *
+ * `changedTasks` and `previousTasks` line up index for index, so a host can diff the two
+ * without looking anything up.
+ */
+export function buildTaskChange({
+  type,
+  taskId,
+  changedIds,
+  previous,
+  next,
+  edge,
+}: BuildTaskChangeParams): GanttTaskChange {
+  const changed = new Set(changedIds);
+  const before = new Map(previous.map((task) => [task.id, task]));
+
+  // Driven off `next` so both arrays come out in render order, not in the order the
+  // subtree walk happened to collect the ids
+  const changedTasks = next.filter((task) => changed.has(task.id));
+  const previousTasks = changedTasks
+    .map((task) => before.get(task.id))
+    .filter((task): task is Task => task !== undefined);
+
+  return {
+    type,
+    task: next.find((task) => task.id === taskId) ?? changedTasks[0],
+    changedTasks,
+    previousTasks,
+    tasks: next,
+    edge,
+  };
+}
+
+/**
+ * Decides commit or rollback for gestures whose before-handler may still be in flight
+ *
+ * A gesture claims its lane on the first movement and settles once the handler answers.
+ * If another gesture claimed the same lane in between, this one lost the bar and its
+ * answer is dropped ('stale') - otherwise a slow veto would drag a bar the user has since
+ * moved somewhere else back to a position nobody asked for.
+ */
+export function createMutationGate() {
+  const generations = new Map<string, number>();
+
+  return {
+    /** Claims a lane and returns the token identifying this gesture */
+    begin(key: string): number {
+      const token = (generations.get(key) ?? 0) + 1;
+      generations.set(key, token);
+      return token;
+    },
+
+    /** Runs the handler and reports what the caller should do with the result */
+    async settle(
+      key: string,
+      token: number,
+      handler: GanttBeforeChangeHandler,
+      change: GanttTaskChange
+    ): Promise<MutationOutcome> {
+      let vetoed: boolean;
+      try {
+        // Only an explicit false is a veto - undefined (the common `void` handler) commits
+        vetoed = (await handler(change)) === false;
+      } catch {
+        // A throw or a rejected promise is the failed-server case: roll back
+        vetoed = true;
+      }
+
+      if (generations.get(key) !== token) return 'stale';
+      return vetoed ? 'rollback' : 'commit';
+    },
+  };
+}
+
+export type MutationGate = ReturnType<typeof createMutationGate>;


### PR DESCRIPTION
Adds the consumer integration surface the library was missing: events with a real selection state, before-events that can cancel a change, and render-prop overrides with per-task colors.

Closes #35
Closes #38

## The callback contract

### Events

`onTaskClick`, `onTaskDoubleClick` and `onTaskSelect` fire from a bar and from its task list row alike — one event, both panes. `selectedTaskId` lives in the per-instance store, so the highlighted bar and the highlighted row can never disagree.

- Passing `onTaskSelect` turns selection on; `selectable` overrides that either way (the same `showTaskList ?? columns !== undefined` convention the chart already uses).
- The click that ends a drag is swallowed, so dragging never registers as a click.
- A double click is still two clicks in the DOM: `onTaskClick` fires twice, `onTaskDoubleClick` once. `onTaskSelect` only fires when the selection actually changes.
- Clicking the empty timeline clears the selection and reports `null`.

### Veto and rollback

`onBeforeTaskChange` runs after a gesture ends and before anything is written — the persistence hook.

| The handler returns | What happens |
|---------------------|--------------|
| nothing, or `true` | committed, `onTasksChange` fires |
| `false` | dropped, the bar animates back |
| a promise resolving to anything but `false` | committed once it settles |
| a promise resolving to `false` | rolled back once it settles |
| a rejected promise, or a synchronous throw | rolled back — the failed-server case |

```tsx
<ReactGanttChart
  tasks={tasks}
  // The bar is already where the user dropped it while this runs
  onBeforeTaskChange={async (change) => {
    const res = await fetch('/api/tasks/bulk', {
      method: 'PATCH',
      body: JSON.stringify(change.changedTasks),
    });
    if (!res.ok) return false;   // 409 -> the bar slides back to where the drag started
  }}
  onTasksChange={setTasks}       // only reached once the change is accepted
/>
```

Three properties worth stating explicitly, because they are what the implementation is actually about:

1. **Optimistic, never frozen.** The bar holds the position the user dropped it at for as long as the promise is pending — it keeps the live drag offsets instead of writing to `rawTasks` — and nothing is disabled meanwhile.
2. **The commit is merged, not replayed.** When the answer arrives, the changed tasks are merged into `rawTasks` *as they are at that moment*, so a slow handler cannot clobber an edit another bar committed while it was waiting.
3. **A newer gesture wins.** Each gesture claims a lane the first time it actually moves the bar. If the user drags that bar again before the answer lands, the late answer is dropped rather than yanking the bar back to a position nobody asked for. Moves and resizes share one lane per task; a progress edit runs in its own, so a pending date change and a progress change never cancel each other.

`GanttTaskChange` carries `type`, the grabbed `task`, `changedTasks` and `previousTasks` (aligned index for index), the full `tasks` array, and `edge` for a resize. Dragging a summary bar carries its whole subtree, so that is one handler call, one decision, one `onTasksChange`.

Dropping a task list row keeps the synchronous `onReorder` veto that landed with #102 — `onBeforeTaskChange` covers the timeline gestures. The README says so at both ends.

### Render props and styling

`renderBar`, `renderTooltip` and `renderHeaderCell` each replace the default node outright and receive the layout they need. `renderBar` gets `barProps` (positioning style plus the pointer/click/double-click handlers) to spread, so a custom bar stays draggable and selectable. `Task` gains `color` (the progress fill and hover shade are derived from it, through CSS variables that fall back to the theme tokens) and `className`.

A default hover tooltip — name, dates, duration, progress — joins the existing drag tooltip, per #38's acceptance criteria. `showTooltip={false}` suppresses both. **This is the one behavior that changes without opting in**; everything else is inert until a prop is passed, and the rendered DOM at rest is byte-identical (verified below).

## Verified in a browser

Chrome against a dev build, synthetic pointer events, timings from `performance.now()` and a `MutationObserver` on the bar:

- **Click** → `onTaskClick` once, `onTaskSelect` once; `.selected` lands on `#task-t1` *and* on its `.gantt-grid-row`. **Double click** → `onTaskDoubleClick` exactly once. Clicking the empty timeline → `onTaskSelect(null)` and zero `.selected` nodes.
- **Veto rollback** (handler rejecting after 500 ms), drag +96 px = 3 days at month scale: `translateX(172px)` → `268px` while dragging → still `268px` 1 ms after pointerup → at t=509 ms the class flips to `gantt-task-bar reverting` and the transform is back to `172px` → at t=710 ms the class clears. The bar held the dropped position for 503 ms and animated back over 201 ms. No `onTasksChange` fired.
- **Second gesture during a pending veto:** two drops on the same bar back to back log two `before` calls; the first answer is dropped and only the second rolls back — one revert, not two.
- **Progress veto:** fill 40% → 90% while dragging → held at 90% → back to 40% on rejection, no `onTasksChange`.
- **Commit path unchanged:** without a before-handler, one `onTasksChange` with `t1` moved Jun 2 → Jun 5.
- **`renderBar`:** 0 default `.gantt-task-bar` nodes, 3 custom ones; dragging through the spread `barProps` moves `172px` → `236px` and commits; clicking a custom bar fires `onTaskClick` + `onTaskSelect` and highlights the grid row.
- **Tooltips:** default hover shows `Design / Jun 2, 2025 → Jun 6, 2025 / 4d · 40%` (formatted through the chart's locale formatters); `renderTooltip` replaces it entirely; `showTooltip={false}` renders none.
- **`renderHeaderCell`:** 29 custom cells, both rows, `cellProps` keeping the 32 px tick widths; zero default header cells left.
- **Per-task color:** bar `rgb(124, 58, 237)`, fill the derived darker purple, an uncolored sibling still `rgb(39, 39, 42)` / `rgb(82, 82, 91)`; `className` on the bar and the row.
- **With none of the new props:** bar class `gantt-task-bar compact`, style `transform: translateX(172px); width: 14px; height: 19px; cursor: grab;` — no custom properties, no `selected`, no tooltip at rest.
- **With `readOnly` (from #101):** the drag does not move the bar, there is no progress handle, the cursor is `default`, and clicking still selects. The veto runs only for gestures the guards already allowed.

## Checks

`pnpm lint` 0 errors / 4 warnings (all pre-existing), `pnpm type-check`, `pnpm test` 201 passing, `pnpm build`.

New unit tests in `src/utils/mutation.test.ts` cover the payload builder, the lane keys, and the state machine end to end — sync `false`, async `false`, a rejected promise, a synchronous throw, a superseded gesture (resolving and rejecting), and independent lanes settling while another is pending. `src/stores/store.test.ts` adds the selection and revert-flag reducers.

Merged `origin/main` (interaction guards, drag bounds, i18n, PNG export, row reordering) before opening; the merge commit lists what had to be reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
