### PR TITLE
chore: add the Agentation toolbar to the dev playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^4.7.0",
+    "agentation": "^3.0.2",
     "eslint": "^9.39.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1))
+      agentation:
+        specifier: ^3.0.2
+        version: 3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       eslint:
         specifier: ^9.39.5
         version: 9.39.5
@@ -755,6 +758,17 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentation@3.0.2:
+    resolution: {integrity: sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -2713,6 +2727,11 @@ snapshots:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
+
+  agentation@3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Agentation } from "agentation";
 import Gantt from "pages/Gantt";
 import { useEffect, useRef, useState } from "react";
 import type { SchedulingPolicy } from "core";
@@ -261,6 +262,7 @@ function App() {
           }
         />
       </div>
+      <Agentation />
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds [Agentation](https://www.agentation.com/) to the Vite dev playground. It renders a click-to-annotate toolbar over the running app and copies the selected element's CSS selector, class names, and React component path as markdown, so UI feedback can be handed straight to a coding agent instead of described in prose.

## How

One `<Agentation />` at the end of `src/App.tsx`.

`src/App.tsx` is the dev playground; the library entry is `src/index.tsx` and `vite.config.ts` already excludes `App.tsx` from the declaration build. Nothing here reaches `dist/` or the npm tarball, so no `NODE_ENV` guard is needed.

## Verification

- `pnpm type-check && pnpm lint && pnpm test && pnpm build` — passes. 433 tests, 20 files. The 4 lint warnings are pre-existing, in `useGanttBarDrag.ts` and `useGanttVirtualization.ts`.
- `grep -c agentation dist/index.js dist/index.cjs` — 0 in both.
- `pnpm dev` — toolbar renders in the bottom-right corner.

## Notes

No public API changed, so the demo page on jaeungkim.com needs no matching update. `agentation` is a devDependency, licensed PolyForm Shield 1.0.0 rather than an OSI license; it is a local dev tool and is not distributed with the MIT-licensed package. Desktop browsers only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)