### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaeungkim/gantt-chart",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": false,
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump only. No source changes.

## Why now

`package.json` and npm `latest` both still read `0.3.1`, but three feature PRs merged without a version bump:

- #107 — headless core, auto-scheduling, working calendar, critical path, baselines
- #109 — keyboard navigation, ARIA treegrid, swimlane grouping
- #112 — bilingual docs site split

The gap is measurable: `GanttProps` on `main` has **60 props**; the published `0.3.1` type declarations expose **7**. Anyone installing from npm gets a build that predates the scheduling engine, and the docs describe an API they cannot reach.

While 0.x, breaking changes bump the minor — per `RELEASING.md`.

## Verification

```
pnpm type-check   ✓
pnpm lint         ✓  0 errors (4 pre-existing warnings)
pnpm test         ✓  20 files, 433 tests passed
pnpm build        ✓  index.js 196.76 kB / gzip 53.43 kB
```

`dist/pages/Gantt.d.ts` confirmed to carry all 60 props after the build.

## After merge

Draft the `v0.4.0` GitHub Release on `main` to trigger `publish.yml` (npm OIDC trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)