### PR TITLE
fix(docs): make the site deployable and stop unlisted pages vanishing

### DIFF
--- a/apps/docs/content/docs/meta.en.json
+++ b/apps/docs/content/docs/meta.en.json
@@ -20,6 +20,7 @@
     "i18n",
     "theming",
     "headless-core",
+    "...",
     "---Reference---",
     "ref"
   ]

--- a/apps/docs/content/docs/meta.ko.json
+++ b/apps/docs/content/docs/meta.ko.json
@@ -20,6 +20,7 @@
     "i18n",
     "theming",
     "headless-core",
+    "...",
     "---레퍼런스---",
     "ref"
   ]

--- a/apps/docs/content/docs/ref/meta.en.json
+++ b/apps/docs/content/docs/ref/meta.en.json
@@ -17,6 +17,7 @@
     "core-graph",
     "core-tree",
     "core-critical-path",
-    "core-calendar"
+    "core-calendar",
+    "..."
   ]
 }

--- a/apps/docs/content/docs/ref/meta.ko.json
+++ b/apps/docs/content/docs/ref/meta.ko.json
@@ -17,6 +17,7 @@
     "core-graph",
     "core-tree",
     "core-critical-path",
-    "core-calendar"
+    "core-calendar",
+    "..."
   ]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "postinstall": "fumadocs-mdx"
+    "postinstall": "fumadocs-mdx",
+    "vercel-build": "pnpm --filter @jaeungkim/gantt-chart build && next build"
   },
   "dependencies": {
     "@jaeungkim/gantt-chart": "workspace:*",


### PR DESCRIPTION
Two things found while setting up the Vercel project.

## The first deploy would have failed

`apps/docs` resolves the library through `workspace:*`, which points at `dist/` — and `dist/` does not exist on a clean checkout. With Vercel's root directory set to `apps/docs`, the default `next build` dies before it starts:

```
Package path ./style.css is exported from package @jaeungkim/gantt-chart,
but no valid target file was found
Module not found: Can't resolve '@jaeungkim/gantt-chart'
```

Vercel prefers a `vercel-build` script over `build`, so that is where the ordering goes:

```json
"vercel-build": "pnpm --filter @jaeungkim/gantt-chart build && next build"
```

Verified by deleting `dist/` and `.next/` and running it: library builds, then 75 static pages. This also means the Vercel project needs **no** build-command override — the default works.

## A page missing from meta.*.json disappeared from the sidebar

The `pages` arrays were fully explicit with no rest entry. An unlisted page still built and was still reachable by URL, but never appeared in navigation — silent, and only noticeable if you went looking for it.

Both languages, root and `ref/`, now end with `"..."`.

Verified with a throwaway page: the sidebar went from 19 links to 20 and the page appeared, where before it was absent from the nav entirely while its route still generated.

## Verification

```
pnpm lint         ✓  0 errors, 4 pre-existing warnings
pnpm type-check   ✓
pnpm test         ✓  20 files, 433 tests passed
pnpm build        ✓
docs build        ✓  75 static pages
vercel-build      ✓  from a clean tree with no dist/ and no .next/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)