### PR TITLE
docs: point the live-demo link at the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A Gantt chart for React: virtualized rows, editable bars, dependency arrows, and a scheduling
 engine that runs without a DOM.
 
-**[Live demo](https://jaeungkim.com/gantt-chart)** · **[Documentation](https://gantt.jaeungkim.com/docs)** · **[한국어 문서](https://gantt.jaeungkim.com/ko/docs)**
+**[Live demo](https://gantt.jaeungkim.com/docs/quick-start)** · **[Documentation](https://gantt.jaeungkim.com/docs)** · **[한국어 문서](https://gantt.jaeungkim.com/ko/docs)**
 
 ## Motivation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ Maintainer runbook. Publishing is triggered by creating a GitHub Release in the 
 5. Issues → Labels → New label:
    - `breaking` `#b60205` — "Changes the public API or behavior; bumps the minor version while 0.x"
    - `skip-changelog` `#cfd3d7` — "Hide from release notes (CI, tooling, release chores)"
-6. Repo home page → About (gear icon): website `https://jaeungkim.com/gantt-chart`, topics `react gantt gantt-chart timeline typescript`.
+6. Repo home page → About (gear icon): website `https://gantt.jaeungkim.com`, topics `react gantt gantt-chart timeline typescript`.
 
 ## Cutting a release (example: 0.4.0)
 


### PR DESCRIPTION
The portfolio's `/gantt-chart` showcase page is being deleted in jaeungkim/portfolio-website-nextjs#98, since the playground and this repo's docs site now cover the same ground. Two links here pointed at that page and would have started 404ing:

- `README.md` — the **Live demo** link, now `https://gantt.jaeungkim.com/docs/quick-start`, which carries a `<GanttDemo />`.
- `RELEASING.md` — the repo About "website" field in the one-time setup checklist, now `https://gantt.jaeungkim.com` (matching `package.json`'s `homepage`).

Docs-only; no source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)