### PR TITLE
feat(site): rebuild the playground console as a floating dev panel

### DIFF
--- a/apps/site/app/global.css
+++ b/apps/site/app/global.css
@@ -31,3 +31,51 @@
   --gantt-font-sans: var(--font-pretendard-latin), var(--font-pretendard-korean),
     -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
+
+/* The playground console. Fumadocs keeps its own motion in `@theme`, so these follow the same
+   shape: a spring entrance for the panel, a short fade for each log line. */
+@theme {
+  --animate-console-in: console-in 220ms cubic-bezier(0.34, 1.32, 0.64, 1);
+  --animate-console-log-in: console-log-in 180ms ease-out;
+}
+
+@keyframes console-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes console-log-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* A <details> section that slides instead of snapping. `interpolate-size` is what makes the
+   `auto` height animatable; where it is missing the section still opens, just without the
+   transition, so no fallback is needed. */
+.console-section {
+  interpolate-size: allow-keywords;
+}
+
+.console-section::details-content {
+  block-size: 0;
+  overflow: hidden;
+  transition:
+    block-size 240ms cubic-bezier(0.16, 1, 0.3, 1),
+    content-visibility 240ms allow-discrete;
+}
+
+.console-section[open]::details-content {
+  block-size: auto;
+}

--- a/apps/site/components/playground/view.tsx
+++ b/apps/site/components/playground/view.tsx
@@ -6,7 +6,7 @@ import {
   type Task,
   type TaskTransformed,
 } from '@jaeungkim/gantt-chart';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DEMO_ANCHOR, demoHolidays, demoTasks } from '@/components/demo/tasks';
 import {
   CONTROLS,
@@ -31,10 +31,48 @@ interface LogEntry {
   detail: string;
 }
 
-const ACTION =
-  'rounded-lg border border-fd-border px-2.5 py-1.5 text-[13px] text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fd-muted-foreground';
+// The dock floats over the chart, so it is glass; the panel has to stay readable over dense
+// rows, so it is not. `dark:` here is fumadocs' `.dark` class, not the media query, so both
+// follow the site's own theme switch rather than the OS.
+const DOCK =
+  'border border-fd-border/70 bg-fd-card/80 backdrop-blur-xl dark:border-white/10 dark:bg-fd-card/70';
 
-const HEADING = 'text-[11px] font-semibold uppercase tracking-wider text-fd-muted-foreground';
+const PANEL = 'border border-fd-border/70 bg-fd-card dark:border-white/10';
+
+// Round, filled on hover, dented on press - the shape agentation's toolbar uses.
+const ICON_BUTTON =
+  'grid size-9 shrink-0 cursor-pointer place-items-center rounded-full text-fd-muted-foreground outline-none transition-[background-color,color,transform] duration-150 hover:bg-fd-accent hover:text-fd-foreground focus-visible:ring-2 focus-visible:ring-fd-ring active:scale-[0.92]';
+
+const ACTION =
+  'rounded-full border border-fd-border/70 px-2.5 py-1 text-[12px] text-fd-muted-foreground transition-[background-color,color,transform] duration-150 hover:bg-fd-accent hover:text-fd-foreground active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fd-muted-foreground disabled:active:scale-100';
+
+const HEADING = 'text-[10.5px] font-semibold uppercase tracking-[0.08em] text-fd-muted-foreground';
+
+const ROW = 'flex items-center justify-between gap-3 py-[5px] text-[12.5px] text-fd-foreground';
+
+// The track is a sibling of the visually hidden input, so `peer-checked` drives both it and the
+// knob it paints with `::after`.
+const SWITCH =
+  'relative h-[18px] w-8 shrink-0 rounded-full bg-fd-border transition-colors duration-200 after:absolute after:left-[2px] after:top-[2px] after:size-[14px] after:rounded-full after:bg-white after:shadow-sm after:transition-transform after:duration-200 peer-checked:bg-fd-primary peer-checked:after:translate-x-[14px] peer-focus-visible:ring-2 peer-focus-visible:ring-fd-ring peer-focus-visible:ring-offset-1 peer-focus-visible:ring-offset-fd-card dark:after:bg-fd-card';
+
+const SELECT =
+  'h-7 w-[7.5rem] cursor-pointer rounded-lg border border-fd-border/70 bg-fd-background/60 px-2 text-[12px] text-fd-foreground outline-none transition-colors hover:border-fd-border focus-visible:ring-2 focus-visible:ring-fd-ring';
+
+const Icon = ({ children, className = 'size-4' }: { children: ReactNode; className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.75"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    {children}
+  </svg>
+);
 
 export function PlaygroundView() {
   const ref = useRef<GanttHandle>(null);
@@ -196,197 +234,226 @@ export function PlaygroundView() {
         />
       </div>
 
-      {/* z-index clears every chart layer and stays under Agentation's 100000 */}
-      <button
-        type="button"
-        data-testid="fullscreen-toggle"
-        aria-pressed={fullscreen}
-        title={fullscreen ? 'Leave fullscreen (Esc)' : 'Fill the window'}
-        className="absolute bottom-16 left-4 z-[1000] flex items-center gap-2 rounded-full border border-fd-border bg-fd-card py-2 pl-3 pr-4 text-[13px] font-medium text-fd-foreground shadow-lg transition-colors hover:bg-fd-accent"
-        onClick={() => setFullscreen((current) => !current)}
+      {/* One dock carries both toggles and anchors the panel, so the corner holds a single object
+          rather than two stacked buttons. z-index clears every chart layer and stays under
+          Agentation's 100000. */}
+      <div
+        className={`absolute bottom-4 left-4 z-[1000] flex items-center gap-1 rounded-full p-1 shadow-lg shadow-black/10 dark:shadow-black/40 ${DOCK}`}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="size-4"
-          aria-hidden="true"
-        >
-          {fullscreen ? (
-            <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3" />
-          ) : (
-            <path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3" />
-          )}
-        </svg>
-        {fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-      </button>
-      {/* A native <details>: the controls are in the DOM but hidden while closed, so a test must
-          click `console-toggle` before touching any control testid. */}
-      <details data-testid="console" className="fixed bottom-4 left-4 z-[1000]">
-        <summary
-          data-testid="console-toggle"
-          title="Console"
-          aria-label="Toggle the console"
-          className="grid size-10 cursor-pointer list-none place-items-center rounded-full bg-fd-primary text-xl text-fd-primary-foreground shadow-lg [&::-webkit-details-marker]:hidden"
-        >
-          &#9881;
-        </summary>
-
-        <div // `[&>*]:shrink-0` - a scrolling flex column would otherwise squash the stats grid.
-          className="absolute bottom-12 left-0 flex max-h-[calc(100svh-80px)] w-[300px] max-w-[calc(100vw-32px)] flex-col gap-4 overflow-y-auto rounded-xl border border-fd-border bg-fd-card p-4 text-[13px] shadow-xl [&>*]:shrink-0">
-
-          <div data-testid="actions" className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className={ACTION}
-              disabled={!todayInRange}
-              title={
-                todayInRange
-                  ? undefined
-                  : `The demo data is pinned to ${DEMO_ANCHOR}, so today is off the rendered range and scrollToToday() is a documented no-op`
-              }
-              onClick={() => ref.current?.scrollToToday()}
-            >
-              Today
-            </button>
-            <button type="button" className={ACTION} onClick={() => ref.current?.zoomToFit()}>
-              Fit
-            </button>
-            <button
-              type="button"
-              className={ACTION}
-              disabled={!first}
-              onClick={() => first && ref.current?.scrollToTask(first.id)}
-            >
-              Scroll to {first?.id}
-            </button>
-            <button
-              type="button"
-              className={ACTION}
-              disabled={!settings.showDetail || !first}
-              title={settings.showDetail ? undefined : 'Turn the detail panel on first'}
-              onClick={() => first && ref.current?.openDetail(first.id)}
-            >
-              Open detail
-            </button>
-            <button
-              type="button"
-              className={ACTION}
-              // `readOnly` blocks creation too, so the button follows both switches.
-              disabled={!settings.allowTaskCreate || settings.readOnly}
-              title={
-                settings.allowTaskCreate && !settings.readOnly
-                  ? undefined
-                  : 'Turn task creation on first'
-              }
-              onClick={() => ref.current?.addTask()}
-            >
-              Add task
-            </button>
-            <button type="button" className={ACTION} onClick={reset}>
-              Reset data
-            </button>
-          </div>
-
-          <dl
-            data-testid="stats"
-            className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-fd-border bg-fd-border"
+        {/* Native <details>: controls stay in the DOM while closed, so a test clicks
+            `console-toggle` first. `contents` keeps the summary in the dock's own flex row. */}
+        <details data-testid="console" className="group/console contents">
+          <summary
+            data-testid="console-toggle"
+            title="Console"
+            aria-label="Toggle the console"
+            className={`${ICON_BUTTON} list-none group-open/console:bg-fd-primary/10 group-open/console:text-fd-primary [&::-webkit-details-marker]:hidden`}
           >
-            {[
-              ['Tasks', String(tasks.length)],
-              ['Scale', settings.scale],
-              ['Selected', selected?.id ?? '-'],
-              ['Rendered range', range],
-            ].map(([term, value]) => (
-              <div key={term} className="bg-fd-card px-2.5 py-1.5">
-                <dt className={HEADING}>{term}</dt>
-                <dd className="mt-0.5 truncate font-mono text-[12px] text-fd-foreground">
-                  {value}
-                </dd>
+            <Icon>
+              <path d="M4 6h9M17.5 6H20M4 12h2.5M11 12h9M4 18h9M17.5 18H20" />
+              <circle cx="13" cy="6" r="2" />
+              <circle cx="8.5" cy="12" r="2" />
+              <circle cx="13" cy="18" r="2" />
+            </Icon>
+          </summary>
+
+          <div
+            className={`absolute bottom-[calc(100%+0.625rem)] left-0 flex max-h-[min(40rem,calc(100svh-8rem))] w-[21rem] max-w-[calc(100vw-2rem)] origin-bottom-left flex-col overflow-hidden rounded-2xl text-[13px] shadow-2xl shadow-black/20 motion-safe:animate-console-in dark:shadow-black/60 ${PANEL}`}
+          >
+            <header className="flex shrink-0 items-center gap-2 border-b border-fd-border/60 px-3.5 py-2.5">
+              <span className="size-1.5 rounded-full bg-fd-primary motion-safe:animate-pulse" />
+              <h2 className="text-[12px] font-semibold tracking-tight text-fd-foreground">
+                Console
+              </h2>
+              <span className="ml-auto font-mono text-[11px] text-fd-muted-foreground">
+                {tasks.length} tasks &middot; {settings.scale}
+              </span>
+            </header>
+
+            <div className="flex flex-1 flex-col overflow-y-auto overscroll-contain px-3.5 [&>*]:shrink-0">
+              <div data-testid="actions" className="flex flex-wrap items-center gap-1.5 py-3">
+                <button
+                  type="button"
+                  className={ACTION}
+                  disabled={!todayInRange}
+                  title={
+                    todayInRange
+                      ? undefined
+                      : `The demo data is pinned to ${DEMO_ANCHOR}, so today is off the rendered range and scrollToToday() is a documented no-op`
+                  }
+                  onClick={() => ref.current?.scrollToToday()}
+                >
+                  Today
+                </button>
+                <button type="button" className={ACTION} onClick={() => ref.current?.zoomToFit()}>
+                  Fit
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  disabled={!first}
+                  onClick={() => first && ref.current?.scrollToTask(first.id)}
+                >
+                  Scroll to {first?.id}
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  disabled={!settings.showDetail || !first}
+                  title={settings.showDetail ? undefined : 'Turn the detail panel on first'}
+                  onClick={() => first && ref.current?.openDetail(first.id)}
+                >
+                  Open detail
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  // `readOnly` blocks creation too, so the button follows both switches.
+                  disabled={!settings.allowTaskCreate || settings.readOnly}
+                  title={
+                    settings.allowTaskCreate && !settings.readOnly
+                      ? undefined
+                      : 'Turn task creation on first'
+                  }
+                  onClick={() => ref.current?.addTask()}
+                >
+                  Add task
+                </button>
+                <button type="button" className={ACTION} onClick={reset}>
+                  Reset data
+                </button>
               </div>
-            ))}
-          </dl>
 
-          {GROUPS.map((group) => (
-            <section key={group} className="flex flex-col gap-2.5">
-              <h3 className={HEADING}>{group}</h3>
-              {CONTROLS.filter((control) => control.group === group).map((control) =>
-                control.type === 'boolean' ? (
-                  <label key={control.key} className="flex cursor-pointer items-start gap-2.5">
-                    <input
-                      data-testid={control.key}
-                      type="checkbox"
-                      className="mt-0.5 size-3.5 shrink-0 accent-fd-primary"
-                      checked={settings[control.key]}
-                      onChange={(e) => update(control.key, e.target.checked)}
-                    />
-                    <span className="flex flex-col">
-                      <span className="text-fd-foreground">{control.label}</span>
-                      <span className="text-[11px] leading-4 text-fd-muted-foreground">
-                        {control.hint}
-                      </span>
-                    </span>
-                  </label>
-                ) : (
-                  <label key={control.key} className="flex flex-col gap-1">
-                    <span className="text-fd-foreground">{control.label}</span>
-                    <span className="text-[11px] leading-4 text-fd-muted-foreground">
-                      {control.hint}
-                    </span>
-                    <select
-                      data-testid={control.key}
-                      className="mt-0.5 h-8 cursor-pointer rounded-lg border border-fd-border bg-fd-background px-2 text-fd-foreground outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-                      value={settings[control.key]}
-                      onChange={(e) => update(control.key, e.target.value as SelectValue)}
-                    >
-                      {control.options.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                )
-              )}
-            </section>
-          ))}
+              {/* The header already carries the task count and the scale, so this holds only what
+                  it does not repeat - and reads as two more rows rather than a second layout. */}
+              <dl data-testid="stats" className="pb-3">
+                {(
+                  [
+                    ['Selected', selected?.id ?? '-'],
+                    ['Rendered range', range],
+                  ] as const
+                ).map(([term, value]) => (
+                  <div key={term} className={`${ROW} py-1`}>
+                    <dt className={HEADING}>{term}</dt>
+                    <dd className="truncate font-mono text-[11.5px] text-fd-foreground">{value}</dd>
+                  </div>
+                ))}
+              </dl>
 
-          <section className="flex flex-col gap-2">
-            <h3 className={`${HEADING} flex items-center justify-between`}>
-              Event log
-              <button
-                type="button"
-                className="text-[11px] normal-case tracking-normal underline underline-offset-2 hover:text-fd-foreground"
-                onClick={() => setLog([])}
-              >
-                Clear
-              </button>
-            </h3>
-            <ol
-              data-testid="event-log"
-              className="max-h-40 overflow-y-auto rounded-lg border border-fd-border p-2 font-mono text-[11.5px] leading-5"
-            >
-              {log.length === 0 && (
-                <li className="px-1 py-1 font-sans text-fd-muted-foreground">
-                  Every callback the chart fires shows up here. Drag a bar, draw a link, click a
-                  row.
-                </li>
-              )}
-              {log.map((entry) => (
-                <li key={entry.id} className="flex gap-2 px-1">
-                  <span className="shrink-0 text-fd-muted-foreground">{entry.at}</span>
-                  <span className="shrink-0 text-fd-foreground">{entry.event}</span>
-                  <span className="truncate text-fd-muted-foreground">{entry.detail}</span>
-                </li>
+              {GROUPS.map((group) => (
+                // Open by default; collapsing a group is how the wall of switches gets down to
+                // the handful a given experiment needs.
+                <details
+                  key={group}
+                  open
+                  className="console-section group/section border-t border-fd-border/50"
+                >
+                  <summary
+                    className={`${HEADING} flex cursor-pointer list-none items-center gap-1.5 py-2.5 transition-colors hover:text-fd-foreground [&::-webkit-details-marker]:hidden`}
+                  >
+                    <Icon className="size-3 transition-transform duration-200 group-open/section:rotate-90">
+                      <path d="m9 6 6 6-6 6" />
+                    </Icon>
+                    {group}
+                  </summary>
+                  <div className="pb-2.5">
+                    {CONTROLS.filter((control) => control.group === group).map((control) =>
+                      control.type === 'boolean' ? (
+                        // The hint is the row's tooltip, not a second line - two lines a switch
+                        // turned the panel into prose you had to scroll past to reach a control.
+                        <label
+                          key={control.key}
+                          className={`${ROW} cursor-pointer`}
+                          title={control.hint}
+                        >
+                          <span>{control.label}</span>
+                          <input
+                            data-testid={control.key}
+                            type="checkbox"
+                            className="peer sr-only"
+                            checked={settings[control.key]}
+                            onChange={(e) => update(control.key, e.target.checked)}
+                          />
+                          <span className={SWITCH} />
+                        </label>
+                      ) : (
+                        <label key={control.key} className={ROW} title={control.hint}>
+                          <span>{control.label}</span>
+                          <select
+                            data-testid={control.key}
+                            className={SELECT}
+                            value={settings[control.key]}
+                            onChange={(e) => update(control.key, e.target.value as SelectValue)}
+                          >
+                            {control.options.map((option) => (
+                              <option key={option} value={option}>
+                                {option}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )
+                    )}
+                  </div>
+                </details>
               ))}
-            </ol>
-          </section>
-        </div>
-      </details>
+            </div>
+
+            {/* Pinned rather than last in the scroll column: the log is what you watch while
+                dragging a bar, so it stays on screen wherever the controls are scrolled to. */}
+            <section className="shrink-0 border-t border-fd-border/60 bg-fd-muted/40 dark:bg-black/20">
+              <h3 className={`${HEADING} flex items-center justify-between px-3.5 py-2`}>
+                Event log
+                <button
+                  type="button"
+                  className="text-[10.5px] normal-case tracking-normal underline underline-offset-2 transition-colors hover:text-fd-foreground"
+                  onClick={() => setLog([])}
+                >
+                  Clear
+                </button>
+              </h3>
+              <ol
+                data-testid="event-log"
+                className="h-24 overflow-y-auto overscroll-contain px-3.5 pb-2.5 font-mono text-[11px] leading-5"
+              >
+                {log.length === 0 && (
+                  <li className="font-sans text-[11.5px] leading-4 text-fd-muted-foreground">
+                    Every callback the chart fires shows up here. Drag a bar, draw a link, click a
+                    row.
+                  </li>
+                )}
+                {log.map((entry) => (
+                  <li key={entry.id} className="flex gap-2 motion-safe:animate-console-log-in">
+                    <span className="shrink-0 text-fd-muted-foreground/70">{entry.at}</span>
+                    <span className="shrink-0 text-fd-primary">{entry.event}</span>
+                    <span className="truncate text-fd-muted-foreground">{entry.detail}</span>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          </div>
+        </details>
+
+        <span className="mx-0.5 h-5 w-px bg-fd-border/70" />
+
+        <button
+          type="button"
+          data-testid="fullscreen-toggle"
+          aria-pressed={fullscreen}
+          title={fullscreen ? 'Leave fullscreen (Esc)' : 'Fill the window'}
+          aria-label={fullscreen ? 'Leave fullscreen' : 'Fill the window'}
+          className={`${ICON_BUTTON} aria-pressed:bg-fd-primary/10 aria-pressed:text-fd-primary`}
+          onClick={() => setFullscreen((current) => !current)}
+        >
+          <Icon>
+            {fullscreen ? (
+              <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3" />
+            ) : (
+              <path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3" />
+            )}
+          </Icon>
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The playground console read as a bordered div bolted to the corner: it snapped open, stacked two unrelated buttons on top of each other, and put a two-line description under every switch — so reaching a control meant scrolling past prose, and the event log was never on screen while you dragged a bar.

Rebuilt against the shape agentation's toolbar uses.

- **One dock.** Both toggles are round icon buttons in a glass pill, so the corner carries a single object instead of a gear circle above a text pill. `data-testid="console"`, `console-toggle` and `fullscreen-toggle` are unchanged.
- **The panel is a surface.** 21rem, rounded, hairline border, layered shadow, spring entrance. Opaque, not glass — it sits over dense rows and has to stay readable.
- **One line per control.** Label left, switch or select right; the hint is now the row's tooltip. Every group is a `<details>` that slides shut, so an experiment can hide the switches it does not touch.
- **No repeated facts.** The header carries the task count and the scale, so the stats hold only what it does not repeat, and the event log is pinned to the bottom of the panel instead of being the last thing in the scroll column.

Motion lives in `global.css` beside fumadocs' own `@theme` tokens. `::details-content` is what makes a section animate; browsers without it simply open the section, so there is no fallback to maintain.

Verified in both themes on the running site, plus `pnpm type-check && pnpm lint && pnpm test && pnpm build` and `pnpm docs:build` (369 tests pass, lint clean apart from three pre-existing warnings in `src/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)