### PR TITLE
fix(bars): stop a full progress fill squaring the bar's right corners

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -989,7 +989,6 @@
 .gantt-task-bar.summary .gantt-progress-fill {
   background: var(--gantt-progress-color, var(--gantt-foreground));
   opacity: 0.25;
-  border-radius: 3px 0 0 3px;
 }
 
 .gantt-task-bar.selected {
@@ -1020,7 +1019,9 @@
   bottom: 0;
   /* Derived from the bar color when there is one, so a colored bar never mixes in the theme gray */
   background: var(--gantt-progress-color, var(--gantt-progress-bg));
-  border-radius: 6px 0 0 6px;
+  /* Inherited, not squared on the right: at 100% the fill covers the whole bar, and a squared
+     right edge painted over the bar's own rounded corners. One shape, both radii. */
+  border-radius: inherit;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## What

A task at `progress: 100` rendered with a rounded left edge and a flat, square right edge, while every other bar stayed a rounded rectangle.

## Why

`.gantt-progress-fill` was `border-radius: 6px 0 0 6px` — rounded on the left, squared on the right so the fill boundary read as a straight cut. At 100% the fill is exactly as wide as the bar, so those square corners painted straight over the bar's own rounded right corners.

The bar cannot clip the fill: the tooltip, the outside label and the link handles are children of the bar too, so `overflow: hidden` would clip them as well.

## Change

The fill inherits the bar's radius. One shape for both, so a full fill lands exactly on the bar's outline, and the `.summary` override that restated the radius at 3px is no longer needed.

The visible trade: a partial fill now has a rounded right edge instead of a flat cut. If the flat cut is worth keeping, the alternative is an `overflow: hidden` wrapper around the fill alone — more markup for the same outcome at 100%.

## Verification

`pnpm type-check && pnpm lint && pnpm test && pnpm build` — 380 tests pass, 0 lint errors (3 pre-existing `react-hooks/refs` warnings in `useGanttBarDrag.ts`, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)