### PR TITLE
refactor(playground): drop the console's event log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,7 @@ scenario is a shareable link (`/playground?groupBy=1&theme=dark`) that still tog
 loaded.
 
 The action bar at the top of the console is the only place the imperative ref API is reachable
-from the UI, and the event log at the bottom prints every callback the chart fires with its
-payload - the fastest way to see what a gesture actually emitted.
+from the UI.
 
 The `chart height` switch exists for layout bugs: a short container is where overflow problems
 show.

--- a/apps/site/app/global.css
+++ b/apps/site/app/global.css
@@ -19,11 +19,10 @@
     -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
 
-/* The playground console. Fumadocs keeps its own motion in `@theme`, so these follow the same
-   shape: a spring entrance for the panel, a short fade for each log line. */
+/* The playground console. Fumadocs keeps its own motion in `@theme`, so this follows the same
+   shape: a spring entrance for the panel. */
 @theme {
   --animate-console-in: console-in 220ms cubic-bezier(0.34, 1.32, 0.64, 1);
-  --animate-console-log-in: console-log-in 180ms ease-out;
   /* The chart's own `--gantt-accent`, which is scoped to `.gantt-container` and so out of reach
      here. Repeating it is what ties the console to the chart rather than to the site's chrome. */
   --color-console-accent: #3b82f6;
@@ -37,17 +36,6 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes console-log-in {
-  from {
-    opacity: 0;
-    transform: translateY(-2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/apps/site/components/playground/view.tsx
+++ b/apps/site/components/playground/view.tsx
@@ -6,7 +6,7 @@ import {
   type Task,
   type TaskTransformed,
 } from '@jaeungkim/gantt-chart';
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DEMO_ANCHOR, demoHolidays, demoTasks } from '@/components/demo/tasks';
 import {
   CONTROLS,
@@ -20,16 +20,6 @@ import {
 
 const status = (task: Task) =>
   task.progress === 100 ? 'Done' : (task.progress ?? 0) > 0 ? 'In progress' : 'Not started';
-
-// Newest first, capped - a long drag fires a lot of callbacks.
-const LOG_LIMIT = 120;
-
-interface LogEntry {
-  id: number;
-  at: string;
-  event: string;
-  detail: string;
-}
 
 // The console floats over the chart, so it follows the chart's own overlay language rather than
 // the site's card: one step lifted off the chart background (#fafafa -> white, #09090b -> zinc
@@ -96,8 +86,6 @@ export function PlaygroundView() {
   const [tasks, setTasks] = useState<Task[]>(demoTasks);
   const [selected, setSelected] = useState<TaskTransformed | null>(null);
   const [range, setRange] = useState<string>('-');
-  const [log, setLog] = useState<LogEntry[]>([]);
-  const logId = useRef(0);
   useEffect(() => writeSettings(settings), [settings]);
 
   // An overlay pinned over the viewport, not requestFullscreen, so the exit control stays visible.
@@ -120,27 +108,12 @@ export function PlaygroundView() {
     ref.current?.setScale(settings.scale);
   }, [settings.scale]);
 
-  const push = useCallback((event: string, detail: unknown) => {
-    setLog((current) =>
-      [
-        {
-          id: logId.current++,
-          at: new Date().toLocaleTimeString([], { hour12: false }),
-          event,
-          detail: typeof detail === 'string' ? detail : JSON.stringify(detail ?? null),
-        },
-        ...current,
-      ].slice(0, LOG_LIMIT)
-    );
-  }, []);
-
   const update = <K extends keyof Settings>(key: K, value: Settings[K]) =>
     setSettings((current) => ({ ...current, [key]: value }));
 
   const reset = () => {
     setTasks(demoTasks);
     setSelected(null);
-    push('reset', 'demo data restored');
   };
 
   // A fresh array every render would make the chart recompute its non-working days each time.
@@ -174,14 +147,8 @@ export function PlaygroundView() {
         <ReactGanttChart
           ref={ref}
           tasks={tasks}
-          onTasksChange={(updated) => {
-            push('onTasksChange', `${updated.length} tasks`);
-            setTasks(updated);
-          }}
-          onDependencyCreate={(change) => push('onDependencyCreate', change)}
-          onDependencyDelete={(change) => push('onDependencyDelete', change)}
+          onTasksChange={setTasks}
           onTaskCreate={(draft) => {
-            push('onTaskCreate', draft);
             // The chart adds nothing itself - the host appends the row.
             setTasks((current) => [
               ...current,
@@ -195,20 +162,10 @@ export function PlaygroundView() {
               },
             ]);
           }}
-          onTaskMove={(change) => push('onTaskMove', change)}
-          onTaskClick={(task) => push('onTaskClick', task.id)}
-          onTaskDoubleClick={(task) => push('onTaskDoubleClick', task.id)}
-          onTaskSelect={(task) => {
-            push('onTaskSelect', task?.id ?? null);
-            setSelected(task);
-          }}
-          onDetailChange={(task) => push('onDetailChange', task?.id ?? null)}
-          onCollapsedChange={(ids) => push('onCollapsedChange', ids)}
-          onRangeChange={(next) => {
-            const label = `${next.start.format('YYYY-MM-DD')} .. ${next.end.format('YYYY-MM-DD')}`;
-            setRange(label);
-            push('onRangeChange', label);
-          }}
+          onTaskSelect={setSelected}
+          onRangeChange={(next) =>
+            setRange(`${next.start.format('YYYY-MM-DD')} .. ${next.end.format('YYYY-MM-DD')}`)
+          }
           readOnly={settings.readOnly}
           // Each `allow*` beats `readOnly`, so only the off state is passed through.
           allowMove={settings.allowMove ? undefined : false}
@@ -410,41 +367,6 @@ export function PlaygroundView() {
                 </details>
               ))}
             </div>
-
-            {/* Pinned rather than last in the scroll column: the log is what you watch while
-                dragging a bar, so it stays on screen wherever the controls are scrolled to. */}
-            <section
-              className={`shrink-0 bg-black/[0.02] dark:bg-white/[0.02] ${DIVIDER}`}
-            >
-              <h3 className={`${HEADING} flex h-8 items-center justify-between px-3.5`}>
-                Event log
-                <button
-                  type="button"
-                  className="text-[10.5px] normal-case tracking-normal underline underline-offset-2 transition-colors hover:text-fd-foreground"
-                  onClick={() => setLog([])}
-                >
-                  Clear
-                </button>
-              </h3>
-              <ol
-                data-testid="event-log"
-                className="console-scroll h-24 overflow-y-auto overscroll-contain px-3.5 pb-2.5 font-mono text-[11px] leading-5"
-              >
-                {log.length === 0 && (
-                  <li className="font-sans text-[11.5px] leading-4 text-fd-muted-foreground">
-                    Every callback the chart fires shows up here. Drag a bar, draw a link, click a
-                    row.
-                  </li>
-                )}
-                {log.map((entry) => (
-                  <li key={entry.id} className="flex gap-2 motion-safe:animate-console-log-in">
-                    <span className="shrink-0 text-fd-muted-foreground/70">{entry.at}</span>
-                    <span className="shrink-0 text-console-accent">{entry.event}</span>
-                    <span className="truncate text-fd-muted-foreground">{entry.detail}</span>
-                  </li>
-                ))}
-              </ol>
-            </section>
           </div>
         </details>
 


### PR DESCRIPTION
The playground console carried an event log pinned to its bottom edge: every callback the chart fired, newest first, capped at 120 entries.

It is gone. What it printed, the page already holds in its own state — the task count and scale sit in the console header, the selection and the rendered range sit in the stats rows. The log's only real job was to keep seven chart props alive (`onDependencyCreate`, `onDependencyDelete`, `onTaskMove`, `onTaskClick`, `onTaskDoubleClick`, `onDetailChange`, `onCollapsedChange`) that did nothing but push a line into it.

Removed:

- the `<section>` itself, its `LogEntry` type, `LOG_LIMIT`, the `log` state, the `logId` counter and the `push` callback
- the seven log-only chart props; the four that also drive state (`onTasksChange`, `onTaskCreate`, `onTaskSelect`, `onRangeChange`) stay and lost their `push` calls
- `--animate-console-log-in` and the `console-log-in` keyframes in `apps/site/app/global.css`
- the sentence in `CONTRIBUTING.md` that pointed readers at it

The console is now the action bar, the stats and the control groups. Net -90 lines.

Verified: `pnpm type-check && pnpm lint && pnpm test && pnpm build` and `pnpm docs:build` all pass (390 tests, 22 files; the 3 eslint warnings in `src/bars/hooks/useGanttBarDrag.ts` are pre-existing and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)