### PR TITLE
fix(bars): stop the drag readout slicing the numerals it half-covers

### DIFF
--- a/apps/site/content/docs/theming.en.mdx
+++ b/apps/site/content/docs/theming.en.mdx
@@ -204,9 +204,9 @@ and the library's base rule have the same specificity, so source order is what d
 }
 ```
 
-That is enough for the 7 tokens the dark block never touches: `--gantt-font-sans`,
-`--gantt-accent`, `--gantt-detail-width`, `--gantt-drag-band`, and the three motion tokens. For
-the other 20 it is not.
+That is enough for the 6 tokens the dark block never touches: `--gantt-font-sans`,
+`--gantt-accent`, `--gantt-detail-width`, and the three motion tokens. For the other 20 it is
+not.
 
 > [!WARNING]
 > A one-line override on `.gantt-container` wins in light mode and loses in dark. The library's

--- a/apps/site/content/docs/theming.ko.mdx
+++ b/apps/site/content/docs/theming.ko.mdx
@@ -201,8 +201,8 @@ OS가 결정해요. `color-scheme`을 한 번도 언급하지 않은 페이지�
 }
 ```
 
-다크 블록이 건드리지 않는 7개 토큰은 이걸로 충분해요. `--gantt-font-sans`, `--gantt-accent`,
-`--gantt-detail-width`, `--gantt-drag-band`, 그리고 모션 토큰 세 개예요. 나머지 20개는 그렇지 않아요.
+다크 블록이 건드리지 않는 6개 토큰은 이걸로 충분해요. `--gantt-font-sans`, `--gantt-accent`,
+`--gantt-detail-width`, 그리고 모션 토큰 세 개예요. 나머지 20개는 그렇지 않아요.
 
 > [!WARNING]
 > `.gantt-container`에 한 줄로 쓴 덮어쓰기는 라이트 모드에서는 이기고 다크 모드에서는 져요.

--- a/src/bars/components/GanttDragGuides.test.ts
+++ b/src/bars/components/GanttDragGuides.test.ts
@@ -135,3 +135,37 @@ describe("drag readout reports the edge the gesture moves", () => {
     );
   });
 });
+
+// A tick numeral is centred in its cell, so a mask edge landing anywhere inside a cell clips that
+// numeral mid-glyph. Snapping the mask out to whole cells is what keeps the ruler readable.
+describe("drag readout never slices a tick numeral", () => {
+  it("masks the covered numerals with the tick row's own colour, not a tint", () => {
+    expect(declaration(".gantt-drag-mask", "background")).toBe(
+      declaration(".gantt-bottom-row", "background")
+    );
+    const mask = block(".gantt-drag-mask");
+    expect(mask).not.toContain("border");
+    expect(mask).not.toContain("box-shadow");
+    expect(mask).not.toContain("opacity");
+  });
+
+  it("lines the mask up with the tick row it stands in for", () => {
+    expect(declaration(".gantt-drag-mask", "top")).toBe(
+      declaration(".gantt-top-header", "height")
+    );
+    expect(declaration(".gantt-drag-mask", "height")).toBe(
+      declaration(".gantt-bottom-row", "height")
+    );
+  });
+
+  it("snaps the mask out to whole cells, off the cells' own widths", () => {
+    expect(guides).toContain("snapDown(boundaries, startX)");
+    expect(guides).toContain("snapUp(boundaries, endX)");
+    expect(guides).toContain("tickBoundaries(bottomRowCells)");
+  });
+
+  // The band token was the last thing painting a colour of its own on the axis
+  it("leaves no band token behind for a container override to reach", () => {
+    expect(css).not.toContain("--gantt-drag-band");
+  });
+});

--- a/src/bars/components/GanttDragGuides.tsx
+++ b/src/bars/components/GanttDragGuides.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import { useGanttStore } from "shared/context";
 import { resolveFormatters } from "shared/utils/i18n";
+import { snapDown, snapUp, tickBoundaries } from "timeline/utils/header";
 
 // The live readout for a move or resize. It is the tick row being precise for the length of one
 // gesture: the exact date is typeset at the edge the gesture is moving, in the row's own 11px
-// type. Nothing is drawn around it - the label paints the tick row's own background, so it blanks
-// the numerals it actually covers and no others, and the rest of the ruler keeps counting.
+// type, and the ruler outside the dragged span keeps counting. Nothing is drawn around it - the
+// numerals the span covers step aside behind a mask in the row's own colour.
 // A move carries both edges, so it writes both. A resize writes only the edge under the pointer:
 // the other end is not changing, and a second label that never moves is one number to ignore.
 // Mounted inside `.gantt-header-wrapper`, which is sticky and `totalWidth` wide - hence no width
@@ -17,9 +18,15 @@ export default function GanttDragGuides() {
   const dragMode = useGanttStore((store) => store.dragMode);
   const selectedScale = useGanttStore((store) => store.selectedScale);
   const localeOptions = useGanttStore((store) => store.localeOptions);
+  const bottomRowCells = useGanttStore((store) => store.bottomRowCells);
   const { edge, range } = useMemo(
     () => resolveFormatters(selectedScale, localeOptions),
     [selectedScale, localeOptions]
+  );
+
+  const boundaries = useMemo(
+    () => tickBoundaries(bottomRowCells),
+    [bottomRowCells]
   );
 
   const offset = currentTask ? dragOffsets[currentTask.id] : undefined;
@@ -28,6 +35,11 @@ export default function GanttDragGuides() {
   const startX = currentTask.barLeft + offset.offsetX;
   const endX = startX + currentTask.barWidth + offset.offsetWidth;
   const width = Math.max(endX - startX, 2);
+
+  // The mask is snapped out to whole cells, because a tick numeral is centred in its cell: an edge
+  // landing mid-numeral would leave half a glyph standing beside the date that replaced it.
+  const maskLeft = snapDown(boundaries, startX);
+  const maskRight = snapUp(boundaries, endX);
 
   const startLabel = edge(offset.offsetStartDate);
   const endLabel = edge(offset.offsetEndDate);
@@ -53,6 +65,10 @@ export default function GanttDragGuides() {
 
   return (
     <div className="gantt-drag-guides" aria-hidden="true">
+      <div
+        className="gantt-drag-mask"
+        style={{ left: `${maskLeft}px`, width: `${maskRight - maskLeft}px` }}
+      />
       <div
         className="gantt-drag-range"
         style={{ left: `${startX}px`, width: `${width}px` }}

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,10 +42,6 @@
 
   --gantt-non-working-bg: rgba(0, 0, 0, 0.035);
 
-  /* Consumed by .gantt-drag-range. Declared here so the documented container-level override
-     reaches it - a declaration on the element itself would beat an inherited one. */
-  --gantt-drag-band: color-mix(in srgb, var(--gantt-accent) 14%, var(--gantt-muted));
-
   --gantt-duration-fast: 150ms;
   --gantt-transition-fast: 150ms ease;
   --gantt-transition-normal: 200ms ease;
@@ -461,10 +457,18 @@
    edge it reports. 44px is .gantt-top-header's height and 28px .gantt-bottom-row's - the tests
    guard both. min-width keeps two labels legible on a span narrower than they are, which is why
    there is no lift into the month row any more. */
+/* The numerals the dragged span covers step aside for the dates that replace them. This is the
+   tick row's own colour, so no shape appears - the ruler goes quiet under the bar and comes back
+   when the pointer lifts. GanttDragGuides snaps it out to whole tick cells, because an edge
+   landing mid-numeral would otherwise slice that numeral down the middle. */
+.gantt-drag-mask {
+  position: absolute;
+  top: 44px;
+  height: 28px;
+  background: var(--gantt-muted);
+}
+
 .gantt-drag-range {
-  /* Opaque rather than a wash: the band stands IN for the tick numerals it covers instead of
-     tinting them, so no date is ever read through it. --gantt-drag-band is inherited from the
-     container, so the band and a label that has lifted out of it are the same surface. */
   position: absolute;
   top: 44px;
   height: 28px;

--- a/src/timeline/utils/header.test.ts
+++ b/src/timeline/utils/header.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { snapDown, snapUp, tickBoundaries } from './header';
+
+// The drag readout masks the tick numerals it stands in for. A numeral is centred in its cell, so
+// a mask edge landing anywhere inside a cell would clip that numeral mid-glyph - these are what
+// round the mask out to whole cells.
+const cells = (...widths: number[]) =>
+  widths.map((widthPx) => ({ startDate: null as never, widthPx }));
+
+describe('tick boundaries', () => {
+  it('walks the cells into cumulative edges, starting at the origin', () => {
+    expect(tickBoundaries(cells(72, 72, 72, 72))).toEqual([0, 72, 144, 216, 288]);
+  });
+
+  it('gives an empty ruler a single origin, so a snap still has something to return', () => {
+    expect(tickBoundaries([])).toEqual([0]);
+  });
+
+  // An edge month can be one cell wide, so the cells are not all the same width
+  it('handles cells of unequal width', () => {
+    expect(tickBoundaries(cells(30, 126, 126))).toEqual([0, 30, 156, 282]);
+  });
+});
+
+describe('snapping to a tick boundary', () => {
+  const boundaries = [0, 72, 144, 216, 288];
+
+  it('leaves a value already on a boundary where it is', () => {
+    expect(snapDown(boundaries, 144)).toBe(144);
+    expect(snapUp(boundaries, 144)).toBe(144);
+  });
+
+  it('opens outward to the cell the value falls in', () => {
+    expect(snapDown(boundaries, 100)).toBe(72);
+    expect(snapUp(boundaries, 100)).toBe(144);
+    expect(snapDown(boundaries, 73)).toBe(72);
+    expect(snapUp(boundaries, 143)).toBe(144);
+  });
+
+  it('clamps rather than running off either end of the ruler', () => {
+    expect(snapDown(boundaries, -40)).toBe(0);
+    expect(snapUp(boundaries, -40)).toBe(0);
+    expect(snapDown(boundaries, 9999)).toBe(288);
+    expect(snapUp(boundaries, 9999)).toBe(288);
+  });
+
+  it('never returns a down-snap above its up-snap, whatever the value', () => {
+    for (let x = -10; x <= 300; x += 7) {
+      expect(snapDown(boundaries, x)).toBeLessThanOrEqual(snapUp(boundaries, x));
+    }
+  });
+
+  it('is safe on a one-boundary ruler, which is what an empty chart gives it', () => {
+    expect(snapDown([0], 500)).toBe(0);
+    expect(snapUp([0], 500)).toBe(0);
+  });
+});

--- a/src/timeline/utils/header.ts
+++ b/src/timeline/utils/header.ts
@@ -1,4 +1,4 @@
-import { GanttTopHeaderGroup } from 'shared/types';
+import { GanttBottomRowCell, GanttTopHeaderGroup } from 'shared/types';
 
 // Merges consecutive groups carrying the same label into one wider group
 export function mergeHeaderGroups(
@@ -16,4 +16,39 @@ export function mergeHeaderGroups(
   }
 
   return merged;
+}
+
+// Where one tick cell ends and the next begins, in the same space as a bar's `barLeft`
+export function tickBoundaries(cells: GanttBottomRowCell[]): number[] {
+  const edges = [0];
+  let x = 0;
+  for (const cell of cells) {
+    x += cell.widthPx;
+    edges.push(x);
+  }
+  return edges;
+}
+
+// Largest boundary at or before `x`, and smallest at or after it. `boundaries` is ascending, so
+// both are one binary search - a chart at day scale can carry a few thousand cells.
+export function snapDown(boundaries: number[], x: number): number {
+  let low = 0;
+  let high = boundaries.length - 1;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (boundaries[mid] <= x) low = mid;
+    else high = mid - 1;
+  }
+  return boundaries[low];
+}
+
+export function snapUp(boundaries: number[], x: number): number {
+  let low = 0;
+  let high = boundaries.length - 1;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (boundaries[mid] >= x) high = mid;
+    else low = mid + 1;
+  }
+  return boundaries[high];
 }


### PR DESCRIPTION
Follow-up to #132, which landed before this fix was pushed.

## The problem

Each readout label paints its own background so it blanks the numerals underneath. But a label's edges land wherever the dragged bar's edges land, and a tick numeral is centred in its cell. So a label routinely covers *part* of a numeral and leaves the rest standing.

Sampling a month-scale move at 16 pointer positions clipped a glyph in 12 of them. On screen that reads as `Jan 12 |1` — the date, then half of the numeral beside it.

## The fix

The numerals the span covers now step aside as a group. The layer paints one mask across the dragged span in `--gantt-muted`, the tick row's own colour, so no shape appears: the ruler goes quiet under the bar and comes back when the pointer lifts.

The mask is **snapped out to whole tick cells**, which is what makes the slicing impossible rather than merely unlikely. Each edge rounds to the cell boundary beyond it, so a numeral is either wholly masked or untouched.

The snap fixes the pinned case for free. A sticky label sliding along a span wider than the viewport is always inside the mask, so it cannot clip a numeral on its way past.

## Also

`--gantt-drag-band` is removed. Nothing has painted it since the band went, and the theming page counted it among the tokens the dark block never touches, so that count drops from 7 to 6 in both languages.

`tickBoundaries`, `snapDown` and `snapUp` live in `timeline/utils/header`, not in the component: the tick row's geometry is a header concern, exporting them from a component file costs fast refresh, and they are worth testing directly.

## Verification

```
pnpm type-check && pnpm lint && pnpm test && pnpm build
pnpm docs:build
```

All green: 402 tests across 23 files, lint 0 errors (3 pre-existing warnings, unchanged from `main`), docs build clean.

Measured in the browser rather than eyeballed. A script drags each of five bars through 21 pointer positions and, for every tick numeral, checks whether any opaque box covers part of it without covering all of it:

| case | positions | numerals sliced |
|---|---|---|
| move, before this fix | 16 | 12 |
| move (`t5`) | 21 | 0 |
| resize end (`t2`) | 21 | 0 |
| resize start (`t2`) | 21 | 0 |
| narrow bar (`t1`) | 21 | 0 |
| zero-length task (`t7`) | 21 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)