### PR TITLE
fix(site): anchor the demo fixture to the current week instead of a fixed date

### DIFF
--- a/apps/site/components/demo/tasks.ts
+++ b/apps/site/components/demo/tasks.ts
@@ -1,7 +1,12 @@
 import type { Task } from '@jaeungkim/gantt-chart';
 
-// Fixed, not `new Date()`: a shifting demo is unreproducible. A Monday, so weekends land predictably.
-const ANCHOR = Date.UTC(2026, 0, 5);
+// Relative to today, not a fixed date: a pinned fixture drifts into the past and takes today off
+// the rendered range with it. Last week's Monday, so weekends land predictably and today sits
+// mid-fixture -- finished tasks behind it, in-progress straddling it, unstarted ahead.
+const NOW = new Date();
+const ANCHOR =
+  Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), NOW.getUTCDate()) -
+  (((NOW.getUTCDay() + 6) % 7) + 7) * 86_400_000;
 
 // The fixture's first day, so a demo opens framed on its own data rather than on today.
 export const DEMO_ANCHOR = new Date(ANCHOR).toISOString().slice(0, 10);

--- a/apps/site/components/playground/view.tsx
+++ b/apps/site/components/playground/view.tsx
@@ -248,7 +248,7 @@ export function PlaygroundView() {
                   title={
                     todayInRange
                       ? undefined
-                      : `The demo data is pinned to ${DEMO_ANCHOR}, so today is off the rendered range and scrollToToday() is a documented no-op`
+                      : 'Today is outside the rendered range, so scrollToToday() is a documented no-op'
                   }
                   onClick={() => ref.current?.scrollToToday()}
                 >


### PR DESCRIPTION
The demo fixture was pinned to `2026-01-05`, so every passing day pushed it further into the past. Eight months on, today sits outside the rendered range: no today line in any `<GanttDemo>`, and the playground's **Today** button is permanently disabled with a tooltip explaining that the data is pinned.

## What changed

- `apps/site/components/demo/tasks.ts` — `ANCHOR` is now last week's Monday, computed at module load instead of a literal. Still a Monday, so weekends land predictably, and today falls mid-fixture: Discovery (100%/70%) behind it, CMS migration (30%) straddling it, Content load and Launch (0%) ahead. That matches what the progress values already claimed.
- `apps/site/components/playground/view.tsx` — the Today button's disabled tooltip no longer names the pinned date. The button still disables when today is off-range, which now only happens after the viewer drags the data far enough.

The chart mounts client-side (`ssr: false`), so nothing stale is baked into the prerendered HTML.

## Verification

```
pnpm type-check   # clean
pnpm lint         # 0 errors, 3 pre-existing warnings
pnpm test         # 408 passed
pnpm docs:build   # 59 pages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)