### PR TITLE
feat(playground): expose every remaining prop and handle method in the console

### DIFF
--- a/apps/site/components/playground/controls.ts
+++ b/apps/site/components/playground/controls.ts
@@ -13,6 +13,10 @@ export interface Settings {
   allowLinkDelete: boolean;
   allowTaskCreate: boolean;
   reorder: boolean;
+  selectable: boolean;
+  vetoLinkCreate: boolean;
+  vetoLinkDelete: boolean;
+  vetoMove: boolean;
   scale: GanttScaleKey;
   zoomOnWheel: boolean;
   infiniteScroll: boolean;
@@ -20,12 +24,19 @@ export interface Settings {
   holidays: boolean;
   workingCalendar: boolean;
   autoScrollOnDrag: boolean;
+  dateBounds: boolean;
+  visibleRange: boolean;
+  customNonWorking: boolean;
+  initialScrollTo: string;
   showDetail: boolean;
+  customDetail: boolean;
+  controlledDetail: boolean;
   // 'host' passes no `theme` prop at all, so the chart inherits the site's color-scheme.
   theme: GanttTheme | 'host';
   locale: string;
   firstDayOfWeek: string;
   showTooltip: boolean;
+  customFormats: boolean;
   chartHeight: string;
 }
 
@@ -77,6 +88,20 @@ export const CONTROLS: readonly Control[] = [
     key: 'showDetail',
     label: 'Detail panel',
     hint: 'Opens on a click; narrows the timeline, never covers it',
+    group: 'Data',
+    type: 'boolean',
+  },
+  {
+    key: 'customDetail',
+    label: 'Custom detail body',
+    hint: '`renderDetail` replaces the built-in field list',
+    group: 'Data',
+    type: 'boolean',
+  },
+  {
+    key: 'controlledDetail',
+    label: 'Controlled detail',
+    hint: '`detailTaskId` drives the panel; the chart only proposes through `onDetailChange`',
     group: 'Data',
     type: 'boolean',
   },
@@ -139,6 +164,35 @@ export const CONTROLS: readonly Control[] = [
   },
 
   {
+    key: 'selectable',
+    label: 'Selectable',
+    hint: 'Off leaves `onTaskSelect` wired but never fires it',
+    group: 'Editing',
+    type: 'boolean',
+  },
+  {
+    key: 'vetoLinkCreate',
+    label: 'Reject new links',
+    hint: '`onDependencyCreate` returns false - the arrow is drawn, then refused',
+    group: 'Editing',
+    type: 'boolean',
+  },
+  {
+    key: 'vetoLinkDelete',
+    label: 'Reject link deletes',
+    hint: '`onDependencyDelete` returns false',
+    group: 'Editing',
+    type: 'boolean',
+  },
+  {
+    key: 'vetoMove',
+    label: 'Reject row moves',
+    hint: '`onTaskMove` returns false - needs Row reorder on',
+    group: 'Editing',
+    type: 'boolean',
+  },
+
+  {
     key: 'scale',
     label: 'Scale',
     hint: 'The chart ships no picker - this select is the host’s',
@@ -190,6 +244,36 @@ export const CONTROLS: readonly Control[] = [
   },
 
   {
+    key: 'dateBounds',
+    label: 'Drag bounds',
+    hint: '`minDate`/`maxDate` clamped to the fixture span',
+    group: 'Timeline',
+    type: 'boolean',
+  },
+  {
+    key: 'visibleRange',
+    label: 'Pinned range',
+    hint: '`visibleStart`/`visibleEnd`, two weeks past the tasks either side',
+    group: 'Timeline',
+    type: 'boolean',
+  },
+  {
+    key: 'customNonWorking',
+    label: 'Custom non-working day',
+    hint: '`isNonWorkingDay` replaces the weekend/holiday check with Fridays',
+    group: 'Timeline',
+    type: 'boolean',
+  },
+  {
+    key: 'initialScrollTo',
+    label: 'Initial scroll',
+    hint: 'Mount-time only, so the chart remounts on a change',
+    group: 'Timeline',
+    type: 'select',
+    options: ['anchor', 'today', 'none'],
+  },
+
+  {
     key: 'theme',
     label: 'Theme',
     hint: '"host" inherits the site, "system" the OS',
@@ -217,6 +301,13 @@ export const CONTROLS: readonly Control[] = [
     key: 'showTooltip',
     label: 'Tooltips',
     hint: 'Hover and drag alike',
+    group: 'Presentation',
+    type: 'boolean',
+  },
+  {
+    key: 'customFormats',
+    label: 'Label overrides',
+    hint: '`formats` beats the locale on the day and week scales',
     group: 'Presentation',
     type: 'boolean',
   },
@@ -251,6 +342,10 @@ export const DEFAULTS: Settings = {
   allowLinkDelete: true,
   allowTaskCreate: true,
   reorder: true,
+  selectable: true,
+  vetoLinkCreate: false,
+  vetoLinkDelete: false,
+  vetoMove: false,
   scale: 'week',
   zoomOnWheel: true,
   infiniteScroll: true,
@@ -258,11 +353,18 @@ export const DEFAULTS: Settings = {
   holidays: true,
   workingCalendar: true,
   autoScrollOnDrag: true,
+  dateBounds: false,
+  visibleRange: false,
+  customNonWorking: false,
+  initialScrollTo: 'anchor',
   showDetail: true,
+  customDetail: false,
+  controlledDetail: false,
   theme: 'host',
   locale: 'en-US',
   firstDayOfWeek: '1',
   showTooltip: true,
+  customFormats: false,
   chartHeight: 'fill',
 };
 

--- a/apps/site/components/playground/view.tsx
+++ b/apps/site/components/playground/view.tsx
@@ -2,6 +2,7 @@
 
 import {
   ReactGanttChart,
+  type GanttFormatOverrides,
   type GanttHandle,
   type Task,
   type TaskTransformed,
@@ -10,13 +11,39 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DEMO_ANCHOR, demoHolidays, demoTasks } from '@/components/demo/tasks';
 import {
   CONTROLS,
-  DEFAULTS,
   GROUPS,
   readSettings,
   writeSettings,
   type Settings,
   type SelectValue,
 } from '@/components/playground/controls';
+
+// The fixture's own span, as dates. Read off `demoTasks` rather than the live `tasks` state, so
+// dragging a bar out to the edge does not drag the bounds along with it.
+const day = (iso: string) => iso.slice(0, 10);
+const FIXTURE_START = day(
+  demoTasks.reduce((first, task) => (task.startDate < first ? task.startDate : first), demoTasks[0].startDate)
+);
+const FIXTURE_END = day(
+  demoTasks.reduce((last, task) => (task.endDate > last ? task.endDate : last), demoTasks[0].endDate)
+);
+
+// A fortnight past the tasks either side, so a pinned range reads apart from the auto-fit one.
+const shift = (iso: string, days: number) =>
+  new Date(Date.parse(`${iso}T00:00:00Z`) + days * 86_400_000).toISOString().slice(0, 10);
+
+// One override per slot, on two scales - enough to see `formats` beat both the locale and the
+// built-in labels. `d` arrives in UTC mode, so `.format()` needs no conversion.
+const DEMO_FORMATS: GanttFormatOverrides = {
+  day: {
+    tick: (d) => d.format('D ddd'),
+    header: (d) => d.format('MMMM YYYY').toUpperCase(),
+    tooltip: (d) => d.format('YYYY/MM/DD HH:mm'),
+  },
+  // The week scale ticks in days and groups in weeks, so the override that reads as a week goes on
+  // the header, not the tick.
+  week: { header: (d) => `week of ${d.format('D MMM')}` },
+};
 
 // The console floats over the chart, so it follows the chart's own overlay language rather than
 // the site's card: one step lifted off the chart background (#fafafa -> white, #09090b -> zinc
@@ -83,6 +110,11 @@ export function PlaygroundView() {
   const [tasks, setTasks] = useState<Task[]>(demoTasks);
   const [selected, setSelected] = useState<TaskTransformed | null>(null);
   const [range, setRange] = useState<string>('-');
+  // Collapse is controlled outright: the chevrons write back through `onCollapsedChange`, which is
+  // also what the two buttons below drive.
+  const [collapsed, setCollapsed] = useState<string[]>([]);
+  // Tracked whether or not `controlledDetail` is on - off, it only feeds the stat row.
+  const [detailId, setDetailId] = useState<string | null>(null);
   useEffect(() => writeSettings(settings), [settings]);
 
   // An overlay pinned over the viewport, not requestFullscreen, so the exit control stays visible.
@@ -111,7 +143,14 @@ export function PlaygroundView() {
   const reset = () => {
     setTasks(demoTasks);
     setSelected(null);
+    setCollapsed([]);
+    setDetailId(null);
   };
+
+  // Only rows that actually have children collapse.
+  const parentIds = tasks
+    .filter((task) => tasks.some((child) => child.parentId === task.id))
+    .map((task) => task.id);
 
   // A fresh array every render would make the chart recompute its non-working days each time.
   const holidays = useMemo(
@@ -143,6 +182,8 @@ export function PlaygroundView() {
       >
         <ReactGanttChart
           ref={ref}
+          // `initialScrollTo` is read once, at mount, so the row only means anything on a remount.
+          key={settings.initialScrollTo}
           tasks={tasks}
           onTasksChange={setTasks}
           onTaskCreate={(draft) => {
@@ -160,9 +201,15 @@ export function PlaygroundView() {
             ]);
           }}
           onTaskSelect={setSelected}
+          selectable={settings.selectable}
           onRangeChange={(next) =>
             setRange(`${next.start.format('YYYY-MM-DD')} .. ${next.end.format('YYYY-MM-DD')}`)
           }
+          // Each veto returns false, which is the documented "reject it" answer - the gesture runs,
+          // the chart draws it, and then nothing is applied.
+          onDependencyCreate={settings.vetoLinkCreate ? () => false : undefined}
+          onDependencyDelete={settings.vetoLinkDelete ? () => false : undefined}
+          onTaskMove={settings.vetoMove ? () => false : undefined}
           readOnly={settings.readOnly}
           // Each `allow*` beats `readOnly`, so only the off state is passed through.
           allowMove={settings.allowMove ? undefined : false}
@@ -172,13 +219,44 @@ export function PlaygroundView() {
           allowLinkDelete={settings.allowLinkDelete ? undefined : false}
           allowTaskCreate={settings.allowTaskCreate ? undefined : false}
           allowReorder={settings.reorder}
+          minDate={settings.dateBounds ? FIXTURE_START : undefined}
+          maxDate={settings.dateBounds ? FIXTURE_END : undefined}
+          visibleStart={settings.visibleRange ? shift(FIXTURE_START, -14) : undefined}
+          visibleEnd={settings.visibleRange ? shift(FIXTURE_END, 14) : undefined}
           height="100%"
           width="100%"
           showTaskList={settings.showTaskList}
           showRowNumbers={settings.showRowNumbers}
+          collapsedIds={collapsed}
+          onCollapsedChange={setCollapsed}
           showDetail={settings.showDetail}
-          defaultScale={DEFAULTS.scale}
-          initialScrollTo={DEMO_ANCHOR}
+          renderDetail={
+            settings.customDetail
+              ? ({ task, close, scale }) => (
+                  <div className="flex flex-col gap-2 p-3 text-[12.5px]">
+                    <strong className="text-[13px]">{task.name}</strong>
+                    <span className="text-fd-muted-foreground">
+                      {task.startDate} &rarr; {task.endDate} &middot; {scale}
+                    </span>
+                    <button type="button" className={ACTION} onClick={close}>
+                      Close
+                    </button>
+                  </div>
+                )
+              : undefined
+          }
+          detailTaskId={settings.controlledDetail ? detailId : undefined}
+          onDetailChange={(task) => setDetailId(task?.id ?? null)}
+          // Seeded from the console, so a remount lands on the scale the console is showing
+          // instead of snapping back to the default.
+          defaultScale={settings.scale}
+          initialScrollTo={
+            settings.initialScrollTo === 'none'
+              ? undefined
+              : settings.initialScrollTo === 'today'
+                ? 'today'
+                : DEMO_ANCHOR
+          }
           // Keeps the console's `scale` row honest when ctrl+wheel or zoomToFit moves the scale.
           onScaleChange={(scale) => update('scale', scale)}
           // 'host' means "no prop" - the chart then inherits the site's color-scheme.
@@ -188,6 +266,10 @@ export function PlaygroundView() {
           hierarchy={settings.hierarchy}
           showNonWorkingDays={settings.showNonWorkingDays}
           holidays={holidays}
+          // Replaces the weekend/holiday check outright, which is why the two rows above stop
+          // mattering while it is on.
+          isNonWorkingDay={settings.customNonWorking ? (date) => date.day() === 5 : undefined}
+          formats={settings.customFormats ? DEMO_FORMATS : undefined}
           workingCalendar={settings.workingCalendar}
           autoScrollOnDrag={settings.autoScrollOnDrag}
           showTooltip={settings.showTooltip}
@@ -249,6 +331,14 @@ export function PlaygroundView() {
                 >
                   Today
                 </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  title={`scrollToDate('${DEMO_ANCHOR}')`}
+                  onClick={() => ref.current?.scrollToDate(DEMO_ANCHOR)}
+                >
+                  Scroll to anchor
+                </button>
                 <button type="button" className={ACTION} onClick={() => ref.current?.zoomToFit()}>
                   Fit
                 </button>
@@ -268,6 +358,32 @@ export function PlaygroundView() {
                   onClick={() => first && ref.current?.openDetail(first.id)}
                 >
                   Open detail
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  disabled={!detailId}
+                  onClick={() => ref.current?.closeDetail()}
+                >
+                  Close detail
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  // Collapsing needs summary rows, and there is nothing to collapse without them.
+                  disabled={!settings.hierarchy || !parentIds.length}
+                  title={settings.hierarchy ? undefined : 'Turn hierarchy on first'}
+                  onClick={() => setCollapsed(parentIds)}
+                >
+                  Collapse all
+                </button>
+                <button
+                  type="button"
+                  className={ACTION}
+                  disabled={!collapsed.length}
+                  onClick={() => setCollapsed([])}
+                >
+                  Expand all
                 </button>
                 <button
                   type="button"
@@ -294,6 +410,8 @@ export function PlaygroundView() {
                 {(
                   [
                     ['Selected', selected?.id ?? '-'],
+                    ['Detail', detailId ?? '-'],
+                    ['Collapsed', collapsed.length ? collapsed.join(', ') : '-'],
                     ['Rendered range', range],
                   ] as const
                 ).map(([term, value]) => (


### PR DESCRIPTION
The playground console covered 26 of the chart's props. The rest — drag bounds, a pinned range, a custom non-working-day rule, label overrides, the veto callbacks, controlled detail and collapse — could only be exercised by editing `view.tsx`. The dev panel is meant to be the whole API surface, so this fills the gaps.

## Added

**Data** — `renderDetail` as a custom body and controlled detail through `detailTaskId` with `onDetailChange` writing back, both next to the `showDetail` switch they qualify.

**Editing** — `selectable`, plus one switch each for the `onDependencyCreate`, `onDependencyDelete` and `onTaskMove` vetoes (each returns `false`, so the gesture runs and is then refused).

**Timeline** — `minDate`/`maxDate` clamped to the fixture span, `visibleStart`/`visibleEnd` pinned a fortnight past it, `isNonWorkingDay` swapping the weekend/holiday check for a Friday rule, and `initialScrollTo` as a select. That last one is read once at mount, so the chart is keyed on it and remounts; `defaultScale` now seeds from the console rather than from `DEFAULTS`, so a remount lands on the scale being shown.

**Presentation** — `formats`, overriding `tick`, `header` and `tooltip` across the day and week scales.

**Actions** — `Scroll to anchor` (`scrollToDate`), `Close detail` (`closeDetail`), and `Collapse all` / `Expand all`. Collapse is controlled outright now (`collapsedIds` + `onCollapsedChange`), which is what those two buttons write to.

**Stats** — the open detail id and the collapsed ids.

Every new row mirrors into the query string like the existing ones, so a scenario stays a shareable link.

## Left out on purpose

- `className` and `width` — nothing to show.
- `defaultCollapsedIds` — the uncontrolled seed of a panel that mirrors its state into the URL.
- `onTaskClick` / `onTaskDoubleClick` — their event log was deliberately removed in #134.
- `getScrollElement` — an escape hatch, not a demo.

## Verified

Rebased onto `main` past #138, #139, #141 and #142 — `detailTrigger` and the `groupBy` switch are gone, so the two detail rows moved into the Data group and no swimlane control was re-added.

`pnpm type-check`, `pnpm lint` (0 errors, the same 3 pre-existing warnings), `pnpm test` (390 passed), `pnpm docs:build` all pass on the rebased branch. Checked in the browser against the dev server: every new control renders, a single click opens the panel with #139's field list, `renderDetail` replaces it, `isNonWorkingDay` shrinks the shading from 2-day weekends to single Fridays, the format overrides rewrite the header row, and the stat rows report the open detail id. No app console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)