### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaeungkim/gantt-chart",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": false,
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump for v1.2.0. Cutting the release follows RELEASING.md.